### PR TITLE
Update command-line-interface.md

### DIFF
--- a/docs/advanced-usage/command-line-interface.md
+++ b/docs/advanced-usage/command-line-interface.md
@@ -14,7 +14,7 @@ If you just want to use Custom Apps and Extensions head over to each specific se
 Make sure config file is created successfully and there is no error, then run:
 
 ```bash
-spicetify backup apply enable-devtool
+spicetify backup apply enable-devtools
 ```
 
 From now, after changing colors in `color.ini` or CSS in `user.css`, you just need to run:


### PR DESCRIPTION
The argument "enable-devtools" is missing an "s", resulting in a command not found error.

Edit: Added an image
![image](https://user-images.githubusercontent.com/40559090/168586827-56b565e6-ff8e-4bb8-a6cd-d49d8692b62c.png)
