### PR TITLE
docs(windows): update spicetify locations

### DIFF
--- a/docs/advanced-usage/custom-apps.md
+++ b/docs/advanced-usage/custom-apps.md
@@ -19,7 +19,7 @@ App folders can be stored in:
 
 | Platform            | Path                                   |
 | ------------------- | -------------------------------------- |
-| **Windows**         | `%userprofile%\.spicetify\CustomApps\` |
+| **Windows**         | `%appdata%\spicetify\CustomApps\`      |
 | **Linux**/**MacOS** | `~/.config/spicetify/CustomApps`       |
 
 - `CustomApps` folder in Spicetify executable directory.

--- a/docs/advanced-usage/extensions.md
+++ b/docs/advanced-usage/extensions.md
@@ -13,7 +13,7 @@ Extension files can be store in:
 
 | Platform            | Path                                   |
 | ------------------- | -------------------------------------- |
-| **Windows**         | `%userprofile%\.spicetify\Extensions\` |
+| **Windows**         | `%appdata%\spicetify\Extensions\`      |
 | **Linux**/**MacOS** | `~/.config/spicetify/Extensions`       |
 
 - `Extensions` folder in Spicetify executable directory.

--- a/docs/advanced-usage/uninstallation.md
+++ b/docs/advanced-usage/uninstallation.md
@@ -8,8 +8,8 @@ description: 🗑 How to remove Spicetify.
 ### Powershell
 ```cmd
 spicetify restore
-rmdir -r -fo $env:USERPROFILE\.spicetify
-rmdir -r -fo $env:USERPROFILE\spicetify-cli
+rmdir -r -fo $env:APPDATA\spicetify
+rmdir -r -fo $env:LOCALAPPDATA\spicetify
 ```
 
 ## Linux and MacOS

--- a/docs/development/themes.md
+++ b/docs/development/themes.md
@@ -9,7 +9,7 @@ There are 2 places you can put your themes:
 
 | Platform            | Path                              |
 | ------------------- | --------------------------------- |
-| **Windows**         | `%userprofile%\.spicetify\Themes` |
+| **Windows**         | `%appdata%\spicetify\Themes`      |
 | **Linux**/**MacOS** | `~/.config/spicetify/Themes`      |
 
 2. `Themes` folder in Spicetify executable directory

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,7 +8,7 @@ The config file is generally located at:
 
 | Platform            | Path                                       |
 | ------------------- | ------------------------------------------ |
-| **Windows**         | `%userprofile%\.spicetify\config-xpui.ini` |
+| **Windows**         | `%appdata%\spicetify\config-xpui.ini`      |
 | **Linux**/**MacOS** | `~/.config/spicetify/config-xpui.ini`      |
 
 However, you can know specifically where it is with:


### PR DESCRIPTION
Update spicetify locations for Windows, in line with the new change in https://github.com/spicetify/spicetify-cli/pull/1801.
