### PR TITLE
fix: update Debian Spotify repo pub key

### DIFF
--- a/docs/advanced-usage/installation.md
+++ b/docs/advanced-usage/installation.md
@@ -87,7 +87,7 @@ Apps installed from Snap **cannot be modified** so you need to follow these step
 2. Install Spotify using `apt`:
 
 ```sh
-curl -sS https://download.spotify.com/debian/pubkey_5E3C45D7B312C643.gpg | sudo apt-key add -
+curl -sS https://download.spotify.com/debian/pubkey_7A3A762FAFD4A51F.gpg  | sudo apt-key add -
 echo "deb http://repository.spotify.com stable non-free" | sudo tee /etc/apt/sources.list.d/spotify.list
 sudo apt-get update && sudo apt-get install spotify-client
 ```


### PR DESCRIPTION
Hi, during install the public key appears to have been changed:
```
$> curl -sS https://download.spotify.com/debian/pubkey_5E3C45D7B312C643.gpg | sudo apt-key add -
echo "deb http://repository.spotify.com stable non-free" | sudo tee /etc/apt/sources.list.d/spotify.list
sudo apt-get update && sudo apt-get install spotify-client
OK
deb http://repository.spotify.com stable non-free
...
Err:6 http://repository.spotify.com stable InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 7A3A762FAFD4A51F
Reading package lists... Done
W: GPG error: http://repository.spotify.com stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 7A3A762FAFD4A51F
E: The repository 'http://repository.spotify.com stable InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```
I propose to update the docs to reflect this change.