### PR TITLE
chore(installation): add MacOS path

### DIFF
--- a/docs/advanced-usage/installation.md
+++ b/docs/advanced-usage/installation.md
@@ -54,6 +54,8 @@ curl -fsSL https://raw.githubusercontent.com/spicetify/spicetify-cli/master/inst
 brew install spicetify/homebrew-tap/spicetify-cli
 ```
 
+On macOS, you will need to set`spotify_path` to `/Applications/Spotify.app/Contents/Resources` in the `~/.config/spicetify/config-xpui.ini` config file.
+
 ### AUR
 
 ```bash


### PR DESCRIPTION
On macOS, the `spotify_path` config must be changed on homebrew installation. This PR tells this to the user so they don't need to go searching through issues on the CLI repo like I did.