### PR TITLE
chore: add `spotify-launcher` aur install details

### DIFF
--- a/docs/advanced-usage/installation.md
+++ b/docs/advanced-usage/installation.md
@@ -66,7 +66,6 @@ yay -S spicetify-cli
 
 Before applying Spicetify, you need to gain write permission on Spotify files, by running command:
 
-<!--This may be outdated as the AUR package for the spotify launcher uses a different install directory-->
 ```bash
 sudo chmod a+wr /opt/spotify
 sudo chmod a+wr /opt/spotify/Apps -R

--- a/docs/advanced-usage/installation.md
+++ b/docs/advanced-usage/installation.md
@@ -71,13 +71,13 @@ sudo chmod a+wr /opt/spotify
 sudo chmod a+wr /opt/spotify/Apps -R
 ```
 
+**Note:** Your Spotify client location might be different.
+
 #### Spotify installed via `spotify-launcher` package (Arch Linux)
 
 If Spotify is installed through the `spotify-launcher` package, then Spotify won't install to `/opt/spotify` and is instead in this folder: `~/.local/share/spotify-launcher/install/usr/share/spotify/`
 
 This directory will need to be added to the `spotify-path` section of the config (and you won't need to change any permissions like the AUR method). 
-
-**Note:** Your Spotify client location might be different.
 
 #### Spotify installed from Snap
 

--- a/docs/advanced-usage/installation.md
+++ b/docs/advanced-usage/installation.md
@@ -66,10 +66,15 @@ yay -S spicetify-cli
 
 Before applying Spicetify, you need to gain write permission on Spotify files, by running command:
 
+<!--This may be outdated as the AUR package for the spotify launcher uses a different install directory-->
 ```bash
 sudo chmod a+wr /opt/spotify
 sudo chmod a+wr /opt/spotify/Apps -R
 ```
+
+If spotify is installed through the `spotify-launcher` package in the AUR then spotify won't install to `/opt/spotify` and is instead in this folder: `~/.local/share/spotify-launcher/install/usr/share/spotify/`
+
+This directory will need to be added to the `spotify-path` section of the config <!--I Don't think the write permission commands are needed with the home directory-->
 
 **Note:** Your Spotify client location might be different.
 

--- a/docs/advanced-usage/installation.md
+++ b/docs/advanced-usage/installation.md
@@ -72,9 +72,11 @@ sudo chmod a+wr /opt/spotify
 sudo chmod a+wr /opt/spotify/Apps -R
 ```
 
-If spotify is installed through the `spotify-launcher` package in the AUR then spotify won't install to `/opt/spotify` and is instead in this folder: `~/.local/share/spotify-launcher/install/usr/share/spotify/`
+#### Spotify installed via `spotify-launcher` package (Arch Linux)
 
-This directory will need to be added to the `spotify-path` section of the config <!--I Don't think the write permission commands are needed with the home directory-->
+If Spotify is installed through the `spotify-launcher` package, then Spotify won't install to `/opt/spotify` and is instead in this folder: `~/.local/share/spotify-launcher/install/usr/share/spotify/`
+
+This directory will need to be added to the `spotify-path` section of the config (and you won't need to change any permissions like the AUR method). 
 
 **Note:** Your Spotify client location might be different.
 


### PR DESCRIPTION
Suggestion for improvements to the AUR section of the advanced installation Not written the best as is just a proposed change due to the aur spotify-launcher package creating it's own folder for the application in the home directory instead of /opt
See comments for little messages