### PR TITLE
docs(api-wrapper/add-to-queue): use `Spicetify.Player.data.item`

### DIFF
--- a/docs/development/api-wrapper/functions/add-to-queue.md
+++ b/docs/development/api-wrapper/functions/add-to-queue.md
@@ -27,7 +27,7 @@ function addToQueue(uri: ContextTrack[]): Promise<void>;
 
 ```ts
 // Add current track to queue
-const currentTrack = Spicetify.Player.data.track;
+const currentTrack = Spicetify.Player.data.item;
 
 await Spicetify.addToQueue([currentTrack]);
 


### PR DESCRIPTION
track property is deprecated since Spicetify v2.23.0 https://github.com/spicetify/spicetify-cli/releases/tag/v2.23.0