### PR TITLE
doc: Updated apt installation with gpg

### DIFF
--- a/docs/advanced-usage/installation.md
+++ b/docs/advanced-usage/installation.md
@@ -89,7 +89,7 @@ Apps installed from Snap **cannot be modified** so you need to follow these step
 2. Install Spotify using `apt`:
 
 ```sh
-curl -sS https://download.spotify.com/debian/pubkey_7A3A762FAFD4A51F.gpg  | sudo apt-key add -
+curl -sS https://download.spotify.com/debian/pubkey_6224F9941A8AA6D1.gpg | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/spotify.gpg
 echo "deb http://repository.spotify.com stable non-free" | sudo tee /etc/apt/sources.list.d/spotify.list
 sudo apt-get update && sudo apt-get install spotify-client
 ```


### PR DESCRIPTION
apt-key is deprecated - Manage keyring files in trusted.gpg.d instead