### PR TITLE
docs(development/react-devtools): correct disabled extensions workaround

### DIFF
--- a/docs/development/react-devtools.md
+++ b/docs/development/react-devtools.md
@@ -17,4 +17,3 @@ You may need to reload the client for the extension to work.
 If you get an error saying that you're not allowed to install extensions, try using the `Force enable Chrome extensions` feature of the ["CEF/Spotify Tweaks" Windhawk mod](https://windhawk.net/mods/cef-titlebar-enabler-universal).
 
 You can find more info about React Developer Tools on the [official React website](https://react.dev/learn/react-developer-tools).
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated React DevTools setup: instructs reloading the client instead of pressing F5 to activate the extension.
  * Replaced prior allowlisted-ID workaround with a recommended Windhawk mod method to force-enable Chrome extensions, including a link and basic usage notes.
  * Clarifies steps to reduce setup friction in environments that restrict extension installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->