### PR TITLE
docs: create documentation-specific issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Report incorrect, outdated, or unclear documentation
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the problem you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Type of issue
+      description: What type of documentation issue is this?
+      options:
+        - Incorrect information
+        - Outdated content
+        - Broken link
+        - Missing information
+        - Typo or grammatical error
+        - Unclear or confusing explanation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: page-url
+    attributes:
+      label: Page URL
+      description: Link to the documentation page with the issue
+      placeholder: https://spicetify.app/docs/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the issue with the documentation
+      placeholder: |
+        What is wrong or missing?
+        What should it say instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix
+      description: If you have a suggestion for how to fix this, please describe it here
+      placeholder: The documentation should say...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Spicetify Discord
+    url: https://discord.gg/VnevqPp2Rr
+    about: Get help from the community on Discord
+  - name: Spicetify CLI Issues
+    url: https://github.com/spicetify/cli/issues
+    about: Report issues with Spicetify CLI (not documentation)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+name: Feature Request
+description: Suggest new documentation or improvements
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Is there an existing request for this?
+      description: Please search to see if a similar request already exists.
+      options:
+        - label: I have searched the existing issues
+          required: true
+
+  - type: dropdown
+    id: request-type
+    attributes:
+      label: Type of request
+      description: What type of documentation improvement are you suggesting?
+      options:
+        - New documentation page
+        - Expand existing documentation
+        - Add examples or code snippets
+        - Add images or diagrams
+        - Improve navigation or organization
+        - Translation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: related-page
+    attributes:
+      label: Related page (if applicable)
+      description: Link to an existing documentation page this relates to
+      placeholder: https://spicetify.app/docs/...
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the documentation you'd like to see
+      placeholder: |
+        What topic should be covered?
+        Why would this be helpful?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Any other context, examples, or references that might help
+    validations:
+      required: false


### PR DESCRIPTION
Create specialized issue templates for the spicetify-docs repository instead of using the default issue template. This resolves #42 by providing templates tailored to documentation contributions.

The new templates include:
- Bug Report: For reporting incorrect, outdated, or unclear documentation
- Feature Request: For suggesting new documentation or improvements
- Config: Disables blank issues and provides helpful contact links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced standardized GitHub issue templates for bug reports and feature requests with structured forms
  * Added template configuration with guided fields, validation, and contact links for improved issue submission

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->