### PR TITLE
docs: add spicetify-nix installation instructions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -260,7 +260,7 @@ For nix-darwin and Home Manager users on macOS, use the [spicetify-nix](https://
 }
 ```
 
-Import the module (`spicetify-nix.darwinModules.spicetify` for nix-darwin or `spicetify-nix.homeManagerModules.spicetify` for Home Manager) and configure `programs.spicetify`. See the Linux "Nix / NixOS" tab above for a configuration example.
+Import the module (`spicetify-nix.darwinModules.spicetify` for nix-darwin or `spicetify-nix.homeManagerModules.spicetify` for Home Manager) and configure `programs.spicetify`. See the [Linux Nix tab](#linux) for a configuration example.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Add installation and configuration instructions for NixOS, Home Manager, and nix-darwin users using the Gerg-L/spicetify-nix flake.

Includes example configurations with module imports, themes, and extensions. References the upstream documentation and notes that the module handles Spotify installation automatically.

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Linux installation guide for Nix and NixOS environments with configuration examples
  * Added macOS installation guide for Nix and nix-darwin environments with module setup guidance
  * Included example code blocks and external documentation links for both platforms

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->