### PR TITLE
Use $HOME variable for prefs_path in documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -256,7 +256,7 @@ Snap apps cannot be modified. You'll need to switch to the apt version:
    ls ~/.var/app/com.spotify.Client/config/spotify/prefs
 
    # Set whichever exists (use the full absolute path):
-   spicetify config prefs_path /home/username/.var/app/com.spotify.Client/config/spotify/prefs
+   spicetify config prefs_path $HOME/.var/app/com.spotify.Client/config/spotify/prefs
    ```
 
 4. Grant permissions:


### PR DESCRIPTION
$HOME is used for completing `/home/<username>/` to be like `/home/celeste` for example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Flatpak setup instructions to use environment variables for configuration paths. Configuration paths now dynamically adapt to your system environment instead of relying on hardcoded references, improving portability and compatibility across different system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->