### PR TITLE
feat: redesign homepage with new hero, themes bento grid, and features section

### DIFF
--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -13,8 +13,9 @@ const {
   type = 'website',
 } = Astro.props;
 
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
-const ogImage = new URL(image, Astro.site);
+const siteBase = Astro.site ?? Astro.url.origin;
+const canonicalURL = new URL(Astro.url.pathname, siteBase);
+const ogImage = new URL(image, siteBase);
 const fullTitle = title === 'Spicetify' ? title : `${title} | Spicetify`;
 ---
 

--- a/src/components/homepage/FeaturesGrid.astro
+++ b/src/components/homepage/FeaturesGrid.astro
@@ -1,0 +1,174 @@
+---
+import ArrowIcon from '../icons/ArrowIcon.astro';
+
+interface Props {
+  features: {
+    icon: string;
+    title: string;
+    description: string;
+    href: string;
+  }[];
+}
+
+const { features } = Astro.props;
+---
+
+<section id="features" class="section features-section" aria-labelledby="features-heading">
+  <div class="section-container">
+    <div class="section-header">
+      <span class="section-tag">Features</span>
+      <h2 id="features-heading">Everything you need</h2>
+      <p>A complete toolkit to customize every corner of Spotify.</p>
+    </div>
+
+    <div class="features-grid">
+      {features.map((feature) => (
+        <a href={feature.href} class="feature-card">
+          <div class="feature-icon" data-icon={feature.icon}>
+            {feature.icon === 'palette' && (
+              <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                <circle cx="13.5" cy="6.5" r="2.5" /><circle cx="17.5" cy="10.5" r="2.5" /><circle cx="8.5" cy="7.5" r="2.5" /><circle cx="6.5" cy="12.5" r="2.5" />
+                <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
+              </svg>
+            )}
+            {feature.icon === 'puzzle' && (
+              <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                <path d="M12 2v4m0 12v4M2 12h4m12 0h4m-3.17-6.83-2.83 2.83m-4 4-2.83 2.83M6.83 5.17l2.83 2.83m4 4 2.83 2.83" />
+              </svg>
+            )}
+            {feature.icon === 'grid' && (
+              <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                <rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" /><rect x="3" y="14" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" />
+              </svg>
+            )}
+            {feature.icon === 'terminal' && (
+              <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                <polyline points="4 17 10 11 4 5" /><line x1="12" y1="19" x2="20" y2="19" />
+              </svg>
+            )}
+          </div>
+          <h3>{feature.title}</h3>
+          <p>{feature.description}</p>
+          <span class="feature-arrow">
+            <ArrowIcon size={14} />
+          </span>
+        </a>
+      ))}
+    </div>
+  </div>
+</section>
+
+<style>
+  .features-section {
+    background: var(--color-bg-secondary);
+  }
+
+  .features-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+  }
+
+  .feature-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    padding: 1.75rem;
+    border-radius: 14px;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg);
+    text-decoration: none;
+    color: var(--color-text);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+    overflow: hidden;
+  }
+
+  .feature-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, var(--accent-subtle) 0%, transparent 50%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+
+  .feature-card:hover {
+    text-decoration: none;
+    transform: translateY(-2px);
+    border-color: var(--accent-border-hover);
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.06);
+  }
+
+  .feature-card:hover::before {
+    opacity: 1;
+  }
+
+  .feature-card:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .feature-icon {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 10px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    margin-bottom: 1rem;
+  }
+
+  .feature-card h3 {
+    position: relative;
+    font-family: var(--font-display);
+    font-size: 1.1rem;
+    font-weight: 700;
+    margin-bottom: 0.4rem;
+  }
+
+  .feature-card p {
+    position: relative;
+    font-size: 0.88rem;
+    color: var(--color-text-secondary);
+    line-height: 1.55;
+    margin: 0;
+  }
+
+  .feature-arrow {
+    position: absolute;
+    top: 1.75rem;
+    right: 1.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--accent-soft);
+    color: var(--accent);
+    opacity: 0;
+    transform: translateX(-4px);
+    transition: opacity 0.25s ease, transform 0.25s ease;
+  }
+
+  .feature-card:hover .feature-arrow {
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .feature-card,
+    .feature-arrow {
+      transition: none !important;
+    }
+  }
+
+  @media (max-width: 900px) {
+    .features-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/components/homepage/HeroSection.astro
+++ b/src/components/homepage/HeroSection.astro
@@ -1,0 +1,401 @@
+---
+import { Image } from 'astro:assets';
+import type { ImageMetadata } from 'astro';
+import ArrowIcon from '../icons/ArrowIcon.astro';
+import GitHubIcon from '../icons/GitHubIcon.astro';
+
+interface Props {
+  stats: { githubStars: string; downloads: string };
+  heroShowcase: { src: ImageMetadata; alt: string; label: string }[];
+}
+
+const { stats, heroShowcase } = Astro.props;
+---
+
+<section id="hero" class="hero" aria-labelledby="hero-heading">
+  <div class="hero-bg">
+    <div class="hero-gradient-orb hero-orb-1"></div>
+    <div class="hero-gradient-orb hero-orb-2"></div>
+    <div class="hero-noise"></div>
+    <div class="hero-grid"></div>
+  </div>
+
+  <div class="hero-content">
+    <div class="hero-badge">
+      <span class="hero-badge-dot"></span>
+      Open Source &middot; {stats.githubStars} Stars &middot; {stats.downloads} Downloads
+    </div>
+
+    <h1 id="hero-heading">
+      <span class="hero-line-1">Make Spotify</span>
+      <span class="hero-line-2">truly yours.</span>
+    </h1>
+
+    <p class="hero-subtitle">
+      Themes. Extensions. Custom apps.<br />
+      The ultimate Spotify customization toolkit.
+    </p>
+
+    <div class="hero-actions">
+      <a href="#install" class="btn btn-primary btn-glow">
+        Get Started
+        <ArrowIcon size={16} strokeWidth={2.5} />
+      </a>
+      <a
+        href="https://github.com/spicetify/cli"
+        class="btn btn-ghost"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <GitHubIcon />
+        View on GitHub
+      </a>
+    </div>
+  </div>
+
+  <div class="hero-showcase">
+    <div class="hero-showcase-track">
+      {heroShowcase.map((item, i) => (
+        <div class="hero-showcase-card">
+          <Image
+            src={item.src}
+            alt={item.alt}
+            widths={[600, 900, 1400]}
+            sizes="(max-width: 768px) 300px, 500px"
+            format="webp"
+            quality={90}
+            loading={i === 0 ? 'eager' : 'lazy'}
+          />
+          <span class="hero-showcase-label">{item.label}</span>
+        </div>
+      ))}
+    </div>
+    <div class="hero-showcase-fade"></div>
+  </div>
+</section>
+
+<style>
+  .hero {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: calc(var(--navbar-height) + 5rem) 1.5rem 0;
+    min-height: 100vh;
+    overflow: hidden;
+  }
+
+  .hero-bg {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    overflow: hidden;
+  }
+
+  .hero-gradient-orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(100px);
+  }
+
+  .hero-orb-1 {
+    top: -15%;
+    left: 30%;
+    width: 600px;
+    height: 600px;
+    background: radial-gradient(circle, rgba(235, 90, 55, 0.2) 0%, transparent 70%);
+    animation: orb-drift-1 12s ease-in-out infinite;
+  }
+
+  .hero-orb-2 {
+    top: 10%;
+    right: 15%;
+    width: 400px;
+    height: 400px;
+    background: radial-gradient(circle, rgba(255, 138, 101, 0.12) 0%, transparent 70%);
+    animation: orb-drift-2 15s ease-in-out infinite;
+  }
+
+  [data-theme='light'] .hero-orb-1 {
+    background: radial-gradient(circle, rgba(235, 90, 55, 0.12) 0%, transparent 70%);
+  }
+
+  [data-theme='light'] .hero-orb-2 {
+    background: radial-gradient(circle, rgba(255, 138, 101, 0.08) 0%, transparent 70%);
+  }
+
+  @keyframes orb-drift-1 {
+    0%, 100% { transform: translate(0, 0) scale(1); }
+    33% { transform: translate(40px, 20px) scale(1.05); }
+    66% { transform: translate(-20px, -10px) scale(0.95); }
+  }
+
+  @keyframes orb-drift-2 {
+    0%, 100% { transform: translate(0, 0) scale(1); }
+    50% { transform: translate(-30px, 30px) scale(1.08); }
+  }
+
+  .hero-noise {
+    position: absolute;
+    inset: 0;
+    background-image: var(--noise-bg);
+    background-size: 200px 200px;
+    opacity: 0.5;
+  }
+
+  [data-theme='dark'] .hero-noise {
+    opacity: 0.4;
+  }
+
+  .hero-grid {
+    position: absolute;
+    inset: 0;
+    background-image:
+      linear-gradient(rgba(235, 90, 55, 0.04) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(235, 90, 55, 0.04) 1px, transparent 1px);
+    background-size: 80px 80px;
+    mask-image: radial-gradient(ellipse 70% 50% at 50% 30%, black 10%, transparent 70%);
+    -webkit-mask-image: radial-gradient(ellipse 70% 50% at 50% 30%, black 10%, transparent 70%);
+  }
+
+  .hero-content {
+    position: relative;
+    text-align: center;
+    max-width: 780px;
+    z-index: 1;
+  }
+
+  .hero-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--accent);
+    background: var(--accent-soft);
+    border: 1px solid var(--accent-border);
+    border-radius: 100px;
+    margin-bottom: 2rem;
+    animation: fade-in-down 0.6s ease 0.1s both;
+  }
+
+  .hero-badge-dot {
+    width: 6px;
+    height: 6px;
+    background: var(--accent);
+    border-radius: 50%;
+    animation: pulse-dot 2s ease-in-out infinite;
+  }
+
+  @keyframes pulse-dot {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.5; transform: scale(1.3); }
+  }
+
+  .hero h1 {
+    font-family: var(--font-display);
+    font-size: clamp(3rem, 7.5vw, 5.5rem);
+    font-weight: 800;
+    line-height: 1.0;
+    letter-spacing: -0.04em;
+    margin-bottom: 1.5rem;
+    animation: fade-in-up 0.7s ease 0.2s both;
+  }
+
+  .hero-line-1 {
+    display: block;
+    background: linear-gradient(135deg, var(--accent) 0%, #ff8a65 60%, #ffab91 100%);
+    background-size: 200% auto;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: gradient-shift 6s ease infinite;
+  }
+
+  @keyframes gradient-shift {
+    0%, 100% { background-position: 0% center; }
+    50% { background-position: 100% center; }
+  }
+
+  .hero-line-2 {
+    display: block;
+  }
+
+  .hero-subtitle {
+    font-size: 1.2rem;
+    color: var(--color-text-secondary);
+    line-height: 1.7;
+    max-width: 480px;
+    margin: 0 auto 2.5rem;
+    animation: fade-in-up 0.7s ease 0.35s both;
+  }
+
+  .hero-actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    animation: fade-in-up 0.7s ease 0.45s both;
+  }
+
+  .hero-showcase {
+    position: relative;
+    width: 100%;
+    max-width: 1200px;
+    margin-top: 4rem;
+    perspective: 1400px;
+    animation: fade-in-up 0.8s ease 0.6s both;
+  }
+
+  .hero-showcase-track {
+    display: flex;
+    gap: 1.25rem;
+    justify-content: center;
+    transform: rotateX(3deg);
+    transform-origin: center bottom;
+    padding: 0 1rem;
+  }
+
+  .hero-showcase-card {
+    position: relative;
+    flex: 0 0 380px;
+    aspect-ratio: 16 / 10;
+    border-radius: 14px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow:
+      0 25px 80px rgba(0, 0, 0, 0.12),
+      0 4px 20px rgba(0, 0, 0, 0.06),
+      inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    transition: transform 0.4s cubic-bezier(0.2, 0, 0, 1), box-shadow 0.4s ease;
+    line-height: 0;
+  }
+
+  [data-theme='light'] .hero-showcase-card {
+    border-color: var(--color-border);
+  }
+
+  [data-theme='dark'] .hero-showcase-card {
+    box-shadow:
+      0 25px 80px rgba(0, 0, 0, 0.5),
+      0 4px 20px rgba(0, 0, 0, 0.3),
+      inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  }
+
+  .hero-showcase-card:hover {
+    transform: translateY(-6px) scale(1.01);
+    box-shadow:
+      0 35px 100px rgba(0, 0, 0, 0.18),
+      0 8px 30px rgba(0, 0, 0, 0.08),
+      0 0 0 1px rgba(235, 90, 55, 0.15);
+  }
+
+  .hero-showcase-card :global(img) {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: top left;
+    display: block;
+  }
+
+  .hero-showcase-label {
+    position: absolute;
+    top: 0.75rem;
+    left: 50%;
+    transform: translateX(-50%);
+    font-family: var(--font-display);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 0.5rem 1rem;
+    background: linear-gradient(135deg, rgba(0, 0, 0, 0.75) 0%, rgba(30, 15, 10, 0.8) 100%);
+    color: rgba(255, 255, 255, 0.95);
+    border-radius: 100px;
+    border: 1px solid var(--accent-border);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    white-space: nowrap;
+  }
+
+  .hero-showcase-fade {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 60%;
+    background: linear-gradient(to bottom, transparent 0%, var(--color-bg) 95%);
+    pointer-events: none;
+  }
+
+  @keyframes fade-in-up {
+    from { opacity: 0; transform: translateY(24px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  @keyframes fade-in-down {
+    from { opacity: 0; transform: translateY(-12px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hero-badge,
+    .hero h1,
+    .hero-subtitle,
+    .hero-actions,
+    .hero-showcase {
+      animation: none !important;
+      opacity: 1 !important;
+    }
+
+    .hero-gradient-orb,
+    .hero-line-1,
+    .hero-badge-dot {
+      animation: none !important;
+    }
+
+    .hero-showcase-card {
+      transition: none !important;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .hero {
+      padding: calc(var(--navbar-height) + 3rem) 1rem 0;
+      min-height: auto;
+    }
+
+    .hero h1 {
+      font-size: 2.5rem;
+    }
+
+    .hero-subtitle {
+      font-size: 1rem;
+    }
+
+    .hero-showcase {
+      margin-top: 3rem;
+      perspective: none;
+    }
+
+    .hero-showcase-track {
+      transform: none;
+      gap: 0.75rem;
+      padding: 0 0.5rem;
+    }
+
+    .hero-showcase-card {
+      flex: 0 0 280px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .hero h1 {
+      font-size: 2rem;
+    }
+
+    .hero-showcase-card {
+      flex: 0 0 240px;
+    }
+  }
+</style>

--- a/src/components/homepage/InstallSection.astro
+++ b/src/components/homepage/InstallSection.astro
@@ -1,0 +1,349 @@
+---
+import DiscordIcon from '../icons/DiscordIcon.astro';
+
+type Props = {};
+---
+
+<section id="install" class="section install-section" aria-labelledby="install-heading">
+  <div class="install-bg">
+    <div class="install-orb"></div>
+    <div class="install-noise"></div>
+  </div>
+  <div class="section-container install-container">
+    <div class="section-header">
+      <span class="section-tag section-tag-bright">Quick Start</span>
+      <h2 id="install-heading" class="install-title">Install in seconds</h2>
+      <p>One command. That's it.</p>
+    </div>
+
+    <div class="install-block">
+      <div class="install-tabs" role="tablist">
+        <button role="tab" aria-selected="true" aria-controls="panel-windows" id="tab-windows" class="install-tab active" tabindex="0">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/></svg>
+          Windows
+        </button>
+        <button role="tab" aria-selected="false" aria-controls="panel-macos" id="tab-macos" class="install-tab" tabindex="-1">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm0 1.5a8.5 8.5 0 110 17 8.5 8.5 0 010-17zm-1 3.5v4H7v1h4v4h1v-4h4v-1h-4V7h-1z"/></svg>
+          macOS / Linux
+        </button>
+      </div>
+      <div class="install-panels">
+        <div role="tabpanel" id="panel-windows" aria-labelledby="tab-windows" class="install-panel active">
+          <span class="install-prompt">$</span>
+          <code>iwr -useb https://raw.githubusercontent.com/spicetify/cli/main/install.ps1 | iex</code>
+        </div>
+        <div role="tabpanel" id="panel-macos" aria-labelledby="tab-macos" class="install-panel" hidden>
+          <span class="install-prompt">$</span>
+          <code>curl -fsSL https://raw.githubusercontent.com/spicetify/cli/main/install.sh | sh</code>
+        </div>
+        <button class="copy-btn" aria-label="Copy command to clipboard" title="Copy to clipboard">
+          <svg class="icon-copy" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+          <svg class="icon-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <div class="install-actions">
+      <a href="/docs/getting-started" class="btn btn-primary btn-glow">
+        Read the Docs
+      </a>
+      <a
+        href="https://discord.gg/VnevqPp2Rr"
+        class="btn btn-ghost"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <DiscordIcon />
+        Join Discord
+      </a>
+    </div>
+  </div>
+</section>
+
+<script is:inline>
+  (function () {
+    function setupInstallTabs() {
+      var tabs = Array.from(document.querySelectorAll('.install-tab'));
+      var panels = document.querySelectorAll('.install-panel');
+
+      function activateTab(tab) {
+        tabs.forEach(function (t) {
+          t.classList.remove('active');
+          t.setAttribute('aria-selected', 'false');
+          t.setAttribute('tabindex', '-1');
+        });
+        panels.forEach(function (p) {
+          p.classList.remove('active');
+          p.hidden = true;
+        });
+
+        tab.classList.add('active');
+        tab.setAttribute('aria-selected', 'true');
+        tab.setAttribute('tabindex', '0');
+        tab.focus();
+        var panelId = tab.getAttribute('aria-controls');
+        var panel = document.getElementById(panelId);
+        if (panel) {
+          panel.classList.add('active');
+          panel.hidden = false;
+        }
+      }
+
+      // Auto-select based on OS
+      var ua = navigator.userAgent.toLowerCase();
+      if (ua.includes('mac') || ua.includes('linux')) {
+        var macTab = document.getElementById('tab-macos');
+        if (macTab) activateTab(macTab);
+      }
+
+      tabs.forEach(function (tab) {
+        tab.addEventListener('click', function () {
+          activateTab(tab);
+        });
+      });
+
+      // Keyboard navigation (WAI-ARIA tabs pattern)
+      var tablist = document.querySelector('.install-tabs');
+      if (tablist) {
+        tablist.addEventListener('keydown', function (e) {
+          var currentIndex = tabs.indexOf(document.activeElement);
+          if (currentIndex === -1) return;
+          var nextIndex;
+          if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+            nextIndex = (currentIndex + 1) % tabs.length;
+          } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+            nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+          } else if (e.key === 'Home') {
+            nextIndex = 0;
+          } else if (e.key === 'End') {
+            nextIndex = tabs.length - 1;
+          } else {
+            return;
+          }
+          e.preventDefault();
+          activateTab(tabs[nextIndex]);
+        });
+      }
+    }
+
+    function setupCopyButton() {
+      var btn = document.querySelector('.copy-btn');
+      if (!btn) return;
+
+      btn.addEventListener('click', function () {
+        var activePanel = document.querySelector('.install-panel.active');
+        if (!activePanel) return;
+        var code = activePanel.querySelector('code');
+        if (!code) return;
+
+        var iconCopy = btn.querySelector('.icon-copy');
+        var iconCheck = btn.querySelector('.icon-check');
+
+        navigator.clipboard.writeText(code.textContent.trim()).then(function () {
+          iconCopy.style.display = 'none';
+          iconCheck.style.display = 'block';
+          setTimeout(function () {
+            iconCopy.style.display = 'block';
+            iconCheck.style.display = 'none';
+          }, 2000);
+        }).catch(function () {
+          // Fallback: select text so user can manually copy
+          var range = document.createRange();
+          range.selectNodeContents(code);
+          var sel = window.getSelection();
+          sel.removeAllRanges();
+          sel.addRange(range);
+          btn.setAttribute('title', 'Text selected — press Ctrl+C to copy');
+        });
+      });
+    }
+
+    setupInstallTabs();
+    setupCopyButton();
+  })();
+</script>
+
+<style>
+  .install-section {
+    overflow: hidden;
+    padding-top: 6rem;
+    padding-bottom: 6rem;
+  }
+
+  .install-bg {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  .install-orb {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 800px;
+    height: 600px;
+    background: radial-gradient(ellipse, rgba(235, 90, 55, 0.1) 0%, transparent 60%);
+  }
+
+  .install-noise {
+    position: absolute;
+    inset: 0;
+    background-image: var(--noise-bg);
+    background-size: 200px 200px;
+    opacity: 0.3;
+  }
+
+  .install-container {
+    position: relative;
+  }
+
+  .install-title {
+    background: linear-gradient(135deg, var(--accent) 0%, #ff8a65 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  /* Terminal block — always dark regardless of theme */
+  .install-block {
+    max-width: 660px;
+    margin: 0 auto;
+    border-radius: 14px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: #0f0f1a;
+    box-shadow:
+      0 25px 80px rgba(0, 0, 0, 0.2),
+      0 0 0 1px rgba(255, 255, 255, 0.04),
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+
+  [data-theme='light'] .install-block {
+    border-color: var(--color-border);
+    box-shadow:
+      0 25px 80px rgba(0, 0, 0, 0.08),
+      0 0 0 1px rgba(0, 0, 0, 0.05);
+  }
+
+  .install-tabs {
+    display: flex;
+    background: rgba(0, 0, 0, 0.3);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .install-tab {
+    flex: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.65rem 1rem;
+    border: none;
+    background: none;
+    color: rgba(255, 255, 255, 0.4);
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: var(--font-sans);
+    transition: color 0.15s ease;
+  }
+
+  .install-tab:hover {
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  .install-tab.active {
+    color: #fff;
+    box-shadow: inset 0 -2px 0 var(--accent);
+  }
+
+  .install-tab:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+  }
+
+  .install-panels {
+    position: relative;
+    padding: 1.25rem 1.5rem;
+    padding-right: 3.5rem;
+    display: flex;
+    align-items: center;
+  }
+
+  .install-panel {
+    display: none;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .install-panel.active {
+    display: flex;
+  }
+
+  .install-prompt {
+    color: var(--accent);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    font-weight: 600;
+    user-select: none;
+    flex-shrink: 0;
+  }
+
+  .install-panel code {
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    color: #e2e8f0;
+    background: none;
+    padding: 0;
+    word-break: break-all;
+    line-height: 1.6;
+  }
+
+  .copy-btn {
+    position: absolute;
+    top: 50%;
+    right: 0.85rem;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 6px;
+    cursor: pointer;
+    color: rgba(255, 255, 255, 0.4);
+    transition: color 0.15s ease, background 0.15s ease;
+  }
+
+  .copy-btn:hover {
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+  }
+
+  .copy-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .install-actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-top: 2.5rem;
+  }
+
+  @media (max-width: 768px) {
+    .install-section {
+      padding-top: 4rem;
+      padding-bottom: 4rem;
+    }
+  }
+</style>

--- a/src/components/homepage/InstallSection.astro
+++ b/src/components/homepage/InstallSection.astro
@@ -70,7 +70,7 @@ type Props = {};
       var tabs = Array.from(document.querySelectorAll('.install-tab'));
       var panels = document.querySelectorAll('.install-panel');
 
-      function activateTab(tab) {
+      function activateTab(tab, shouldFocus) {
         tabs.forEach(function (t) {
           t.classList.remove('active');
           t.setAttribute('aria-selected', 'false');
@@ -84,7 +84,7 @@ type Props = {};
         tab.classList.add('active');
         tab.setAttribute('aria-selected', 'true');
         tab.setAttribute('tabindex', '0');
-        tab.focus();
+        if (shouldFocus) tab.focus();
         var panelId = tab.getAttribute('aria-controls');
         var panel = document.getElementById(panelId);
         if (panel) {
@@ -97,12 +97,12 @@ type Props = {};
       var ua = navigator.userAgent.toLowerCase();
       if (ua.includes('mac') || ua.includes('linux')) {
         var macTab = document.getElementById('tab-macos');
-        if (macTab) activateTab(macTab);
+        if (macTab) activateTab(macTab, false);
       }
 
       tabs.forEach(function (tab) {
         tab.addEventListener('click', function () {
-          activateTab(tab);
+          activateTab(tab, true);
         });
       });
 
@@ -125,7 +125,7 @@ type Props = {};
             return;
           }
           e.preventDefault();
-          activateTab(tabs[nextIndex]);
+          activateTab(tabs[nextIndex], true);
         });
       }
     }

--- a/src/components/homepage/ThemesBento.astro
+++ b/src/components/homepage/ThemesBento.astro
@@ -1,0 +1,179 @@
+---
+import { Image } from 'astro:assets';
+import type { ImageMetadata } from 'astro';
+import ArrowIcon from '../icons/ArrowIcon.astro';
+
+interface Props {
+  themes: { src: ImageMetadata; alt: string; label: string }[];
+  marketplaceItems: string;
+}
+
+const { themes, marketplaceItems } = Astro.props;
+---
+
+<section id="themes" class="section themes-section" aria-labelledby="themes-heading">
+  <div class="section-header">
+    <span class="section-tag">Showcase</span>
+    <h2 id="themes-heading">Themes for every taste</h2>
+    <p>Browse community-made themes that completely transform Spotify.</p>
+  </div>
+
+  <div class="themes-bento">
+    {themes.map((theme, i) => (
+      <div class:list={['bento-card', `bento-${i + 1}`]}>
+        <Image
+          src={theme.src}
+          alt={theme.alt}
+          widths={[600, 900, 1400]}
+          sizes={`(max-width: 768px) 90vw, ${i === 0 ? '66vw' : '33vw'}`}
+          format="webp"
+          quality={90}
+          loading="lazy"
+        />
+        <span class="bento-label">{theme.label}</span>
+      </div>
+    ))}
+  </div>
+
+  <div class="themes-cta">
+    <a href="/docs/customization/themes" class="browse-link">
+      Browse all themes
+      <ArrowIcon size={16} />
+    </a>
+    <span class="themes-count">{marketplaceItems} items in the Marketplace</span>
+  </div>
+</section>
+
+<style>
+  .themes-section {
+    padding-top: 2rem;
+    padding-bottom: 4rem;
+  }
+
+  .themes-bento {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-auto-rows: 200px;
+    gap: 0.75rem;
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  .bento-1 { grid-column: span 2; grid-row: span 2; }
+
+  .bento-card {
+    position: relative;
+    overflow: hidden;
+    border-radius: 14px;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg-secondary);
+    line-height: 0;
+    cursor: default;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+  }
+
+  .bento-card:hover {
+    transform: translateY(-3px);
+    border-color: var(--accent-border-hover);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.1);
+  }
+
+  [data-theme='dark'] .bento-card:hover {
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+  }
+
+  .bento-card :global(img) {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: top left;
+    display: block;
+    transition: transform 0.5s cubic-bezier(0.2, 0, 0, 1);
+  }
+
+  .bento-card:hover :global(img) {
+    transform: scale(1.03);
+  }
+
+  .bento-label {
+    position: absolute;
+    bottom: 0.6rem;
+    left: 0.6rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    padding: 0.25rem 0.6rem;
+    background: rgba(0, 0, 0, 0.7);
+    color: #fff;
+    border-radius: 6px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    line-height: 1.4;
+  }
+
+  .bento-1 .bento-label {
+    font-size: 0.85rem;
+    padding: 0.3rem 0.75rem;
+    bottom: 0.75rem;
+    left: 0.75rem;
+  }
+
+  .themes-cta {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-top: 2.5rem;
+  }
+
+  .browse-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--accent);
+    text-decoration: none;
+    transition: gap 0.2s ease;
+  }
+
+  .browse-link:hover {
+    text-decoration: none;
+    gap: 0.6rem;
+  }
+
+  .browse-link:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  .themes-count {
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+    font-weight: 500;
+    padding-left: 1.25rem;
+    border-left: 1px solid var(--color-border);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .bento-card,
+    .bento-card :global(img) {
+      transition: none !important;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .themes-bento {
+      grid-template-columns: repeat(2, 1fr);
+      grid-auto-rows: 160px;
+    }
+
+    .bento-1 { grid-column: span 2; grid-row: span 2; }
+
+    .themes-count {
+      border-left: none;
+      padding-left: 0;
+    }
+  }
+</style>

--- a/src/components/icons/ArrowIcon.astro
+++ b/src/components/icons/ArrowIcon.astro
@@ -1,0 +1,10 @@
+---
+interface Props {
+  size?: number;
+  strokeWidth?: number;
+}
+
+const { size = 16, strokeWidth = 2 } = Astro.props;
+---
+
+<svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width={strokeWidth}><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></svg>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -23,6 +23,9 @@ const fullTitle = title === 'Spicetify' ? title : `${title} | Spicetify`;
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="/images/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Syne:wght@600;700;800&display=swap" />
     <title>{fullTitle}</title>
     <SEO title={title} description={description} image={image} type={type} />
     <script is:inline>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -73,168 +73,245 @@ const heroShowcase = [
     label: 'Extensions',
   },
 ];
+
+const features = [
+  {
+    icon: 'palette',
+    title: 'Themes',
+    description:
+      'Transform your Spotify with community color schemes, layouts, and visual overhauls.',
+    href: '/docs/customization/themes',
+  },
+  {
+    icon: 'puzzle',
+    title: 'Extensions',
+    description:
+      'Add keyboard shortcuts, playback controls, and integrations with other services.',
+    href: '/docs/customization/extensions',
+  },
+  {
+    icon: 'grid',
+    title: 'Custom Apps',
+    description:
+      'Build entirely new pages inside Spotify for lyrics, stats, and more.',
+    href: '/docs/customization/custom-apps',
+  },
+  {
+    icon: 'terminal',
+    title: 'Powerful CLI',
+    description:
+      'Full control from the command line. Apply, backup, restore, and update with ease.',
+    href: '/docs/getting-started',
+  },
+];
 ---
 
 <BaseLayout title="Spicetify" description="Powerful CLI tool to take control of the Spotify client.">
-  <section id="hero" class="hero">
-    <div class="hero-glow"></div>
-    <div class="hero-grid-pattern"></div>
-    <div class="hero-content">
-      <div class="hero-badge">
-        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-        </svg>
-        Open Source &middot; {stats.githubStars} Stars on GitHub &middot; {stats.downloads} Downloads
+  <div class="home-page">
+    <!-- HERO -->
+    <section id="hero" class="hero">
+      <div class="hero-bg">
+        <div class="hero-gradient-orb hero-orb-1"></div>
+        <div class="hero-gradient-orb hero-orb-2"></div>
+        <div class="hero-noise"></div>
+        <div class="hero-grid"></div>
       </div>
-      <h1><span class="hero-gradient">Make Spotify</span> yours.</h1>
-      <p class="hero-subtitle">
-        Customize themes, inject extensions, and unlock the full potential of your Spotify client.
-      </p>
-      <div class="hero-actions">
-        <a href="#install" class="btn btn-primary">
-          Get Started
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></svg>
-        </a>
-        <a
-          href="https://github.com/spicetify/cli"
-          class="btn btn-secondary"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <GitHubIcon />
-          GitHub
-        </a>
-      </div>
-    </div>
-    <div class="hero-showcase">
-      <div class="hero-showcase-track">
-        {heroShowcase.map((item) => (
-          <div class="hero-showcase-card">
-            <Image
-              src={item.src}
-              alt={item.alt}
-              widths={[400, 700]}
-              sizes="(max-width: 768px) 280px, 380px"
-              format="webp"
-              quality={80}
-              loading="eager"
-            />
-            <span class="hero-showcase-label">{item.label}</span>
-          </div>
-        ))}
-      </div>
-    </div>
-  </section>
 
-  <section id="themes" class="section themes-section">
-    <div class="section-container">
-      <h2 class="section-title">Themes for every taste</h2>
-      <p class="section-subtitle">Explore community-made themes that transform your Spotify experience.</p>
-      <div class="bento-grid">
+      <div class="hero-content">
+        <div class="hero-badge">
+          <span class="hero-badge-dot"></span>
+          Open Source &middot; {stats.githubStars} Stars &middot; {stats.downloads} Downloads
+        </div>
+
+        <h1>
+          <span class="hero-line-1">Make Spotify</span>
+          <span class="hero-line-2">truly yours.</span>
+        </h1>
+
+        <p class="hero-subtitle">
+          Themes. Extensions. Custom apps.<br />
+          The ultimate Spotify customization toolkit.
+        </p>
+
+        <div class="hero-actions">
+          <a href="#install" class="btn btn-primary btn-glow">
+            Get Started
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></svg>
+          </a>
+          <a
+            href="https://github.com/spicetify/cli"
+            class="btn btn-ghost"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <GitHubIcon />
+            View on GitHub
+          </a>
+        </div>
+      </div>
+
+      <div class="hero-showcase">
+        <div class="hero-showcase-track">
+          {heroShowcase.map((item) => (
+            <div class="hero-showcase-card">
+              <Image
+                src={item.src}
+                alt={item.alt}
+                widths={[600, 900, 1400]}
+                sizes="(max-width: 768px) 300px, 500px"
+                format="webp"
+                quality={90}
+                loading="eager"
+              />
+              <span class="hero-showcase-label">{item.label}</span>
+            </div>
+          ))}
+        </div>
+        <div class="hero-showcase-fade"></div>
+      </div>
+    </section>
+
+    <!-- THEMES -->
+    <section id="themes" class="section themes-section">
+      <div class="section-header">
+        <span class="section-tag">Showcase</span>
+        <h2>Themes for every taste</h2>
+        <p>Browse community-made themes that completely transform Spotify.</p>
+      </div>
+
+      <div class="themes-bento">
         {themes.map((theme, i) => (
-          <div class:list={['bento-item', `bento-${i + 1}`]}>
+          <div class:list={['bento-card', `bento-${i + 1}`]}>
             <Image
               src={theme.src}
               alt={theme.alt}
-              widths={[400, 800, 1200]}
-              sizes="(max-width: 768px) 50vw, (max-width: 1100px) 33vw, 400px"
+              widths={[600, 900, 1400]}
+              sizes={`(max-width: 768px) 90vw, ${i === 0 ? '66vw' : '33vw'}`}
               format="webp"
-              quality={80}
+              quality={90}
               loading="lazy"
             />
-            <span class="theme-label">{theme.label}</span>
+            <span class="bento-label">{theme.label}</span>
           </div>
         ))}
       </div>
-      <div class="browse-row">
+
+      <div class="themes-cta">
         <a href="/docs/customization/themes" class="browse-link">
           Browse all themes
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></svg>
         </a>
-        <span class="browse-stat">{stats.marketplaceItems} items in the Marketplace</span>
+        <span class="themes-count">{stats.marketplaceItems} items in the Marketplace</span>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <section id="features" class="section features-section">
-    <div class="section-container">
-      <h2 class="section-title">Everything you need</h2>
-      <p class="section-subtitle">Customize every corner of your Spotify client.</p>
-      <div class="features-grid">
-        <a href="/docs/customization/themes" class="feature-card">
-          <div class="feature-icon">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-              <circle cx="13.5" cy="6.5" r="2.5" /><circle cx="17.5" cy="10.5" r="2.5" /><circle cx="8.5" cy="7.5" r="2.5" /><circle cx="6.5" cy="12.5" r="2.5" />
-              <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
-            </svg>
-          </div>
-          <h3>Themes</h3>
-          <p>Transform your Spotify client with community-made color schemes, layouts, and visual overhauls.</p>
-        </a>
-        <a href="/docs/customization/extensions" class="feature-card">
-          <div class="feature-icon">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-              <path d="M12 2v4m0 12v4M2 12h4m12 0h4m-3.17-6.83-2.83 2.83m-4 4-2.83 2.83M6.83 5.17l2.83 2.83m4 4 2.83 2.83" />
-            </svg>
-          </div>
-          <h3>Extensions</h3>
-          <p>Add new features like keyboard shortcuts, playback controls, and integrations with other services.</p>
-        </a>
-        <a href="/docs/customization/custom-apps" class="feature-card">
-          <div class="feature-icon">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-              <rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" /><rect x="3" y="14" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" />
-            </svg>
-          </div>
-          <h3>Custom Apps</h3>
-          <p>Build entirely new pages inside Spotify for lyrics, stats, library management, and more.</p>
-        </a>
-      </div>
-    </div>
-  </section>
-
-  <section id="install" class="section install-section">
-    <div class="install-glow"></div>
-    <div class="section-container">
-      <h2 class="section-title install-title">Install in seconds</h2>
-      <p class="section-subtitle">One command to get started.</p>
-      <p class="section-subtitle section-subtitle-secondary">Join thousands of users who have made Spotify their own.</p>
-      <div class="install-block">
-        <div class="install-tabs" role="tablist">
-          <button role="tab" aria-selected="true" aria-controls="panel-windows" id="tab-windows" class="install-tab active">Windows</button>
-          <button role="tab" aria-selected="false" aria-controls="panel-macos" id="tab-macos" class="install-tab">macOS / Linux</button>
+    <!-- FEATURES -->
+    <section id="features" class="section features-section">
+      <div class="section-container">
+        <div class="section-header">
+          <span class="section-tag">Features</span>
+          <h2>Everything you need</h2>
+          <p>A complete toolkit to customize every corner of Spotify.</p>
         </div>
-        <div class="install-panels">
-          <div role="tabpanel" id="panel-windows" aria-labelledby="tab-windows" class="install-panel active">
-            <code>iwr -useb https://raw.githubusercontent.com/spicetify/cli/main/install.ps1 | iex</code>
-          </div>
-          <div role="tabpanel" id="panel-macos" aria-labelledby="tab-macos" class="install-panel" hidden>
-            <code>curl -fsSL https://raw.githubusercontent.com/spicetify/cli/main/install.sh | sh</code>
-          </div>
-          <button class="copy-btn" aria-label="Copy command to clipboard" title="Copy to clipboard">
-            <svg class="icon-copy" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-            </svg>
-            <svg class="icon-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none">
-              <polyline points="20 6 9 17 4 12" />
-            </svg>
-          </button>
+
+        <div class="features-grid">
+          {features.map((feature) => (
+            <a href={feature.href} class="feature-card">
+              <div class="feature-icon" data-icon={feature.icon}>
+                {feature.icon === 'palette' && (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <circle cx="13.5" cy="6.5" r="2.5" /><circle cx="17.5" cy="10.5" r="2.5" /><circle cx="8.5" cy="7.5" r="2.5" /><circle cx="6.5" cy="12.5" r="2.5" />
+                    <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
+                  </svg>
+                )}
+                {feature.icon === 'puzzle' && (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <path d="M12 2v4m0 12v4M2 12h4m12 0h4m-3.17-6.83-2.83 2.83m-4 4-2.83 2.83M6.83 5.17l2.83 2.83m4 4 2.83 2.83" />
+                  </svg>
+                )}
+                {feature.icon === 'grid' && (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" /><rect x="3" y="14" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" />
+                  </svg>
+                )}
+                {feature.icon === 'terminal' && (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <polyline points="4 17 10 11 4 5" /><line x1="12" y1="19" x2="20" y2="19" />
+                  </svg>
+                )}
+              </div>
+              <h3>{feature.title}</h3>
+              <p>{feature.description}</p>
+              <span class="feature-arrow">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></svg>
+              </span>
+            </a>
+          ))}
         </div>
       </div>
-      <div class="install-actions">
-        <a href="/docs/getting-started" class="btn btn-primary">Get Started</a>
-        <a
-          href="https://discord.gg/VnevqPp2Rr"
-          class="btn btn-secondary"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <DiscordIcon />
-          Join Discord
-        </a>
+    </section>
+
+    <!-- INSTALL -->
+    <section id="install" class="section install-section">
+      <div class="install-bg">
+        <div class="install-orb"></div>
+        <div class="install-noise"></div>
       </div>
-    </div>
-  </section>
+      <div class="section-container install-container">
+        <div class="section-header">
+          <span class="section-tag section-tag-bright">Quick Start</span>
+          <h2 class="install-title">Install in seconds</h2>
+          <p>One command. That's it.</p>
+        </div>
+
+        <div class="install-block">
+          <div class="install-tabs" role="tablist">
+            <button role="tab" aria-selected="true" aria-controls="panel-windows" id="tab-windows" class="install-tab active">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/></svg>
+              Windows
+            </button>
+            <button role="tab" aria-selected="false" aria-controls="panel-macos" id="tab-macos" class="install-tab">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm0 1.5a8.5 8.5 0 110 17 8.5 8.5 0 010-17zm-1 3.5v4H7v1h4v4h1v-4h4v-1h-4V7h-1z"/></svg>
+              macOS / Linux
+            </button>
+          </div>
+          <div class="install-panels">
+            <div role="tabpanel" id="panel-windows" aria-labelledby="tab-windows" class="install-panel active">
+              <span class="install-prompt">$</span>
+              <code>iwr -useb https://raw.githubusercontent.com/spicetify/cli/main/install.ps1 | iex</code>
+            </div>
+            <div role="tabpanel" id="panel-macos" aria-labelledby="tab-macos" class="install-panel" hidden>
+              <span class="install-prompt">$</span>
+              <code>curl -fsSL https://raw.githubusercontent.com/spicetify/cli/main/install.sh | sh</code>
+            </div>
+            <button class="copy-btn" aria-label="Copy command to clipboard" title="Copy to clipboard">
+              <svg class="icon-copy" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+              </svg>
+              <svg class="icon-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none">
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="install-actions">
+          <a href="/docs/getting-started" class="btn btn-primary btn-glow">
+            Read the Docs
+          </a>
+          <a
+            href="https://discord.gg/VnevqPp2Rr"
+            class="btn btn-ghost"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <DiscordIcon />
+            Join Discord
+          </a>
+        </div>
+      </div>
+    </section>
+  </div>
 </BaseLayout>
 
 <script is:inline>
@@ -298,7 +375,6 @@ const heroShowcase = [
             iconCheck.style.display = 'none';
           }, 2000);
         }).catch(function () {
-          // Fallback: select text
           var range = document.createRange();
           range.selectNodeContents(code);
           var sel = window.getSelection();
@@ -308,14 +384,44 @@ const heroShowcase = [
       });
     }
 
+    // Scroll-triggered reveal animations
+    function setupScrollReveal() {
+      var observer = new IntersectionObserver(function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('revealed');
+            observer.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+
+      document.querySelectorAll('.reveal-on-scroll').forEach(function (el) {
+        observer.observe(el);
+      });
+    }
+
     setupInstallTabs();
     setupCopyButton();
+    setupScrollReveal();
   })();
 </script>
 
 <style>
+  @import url('https://fonts.googleapis.com/css2?family=Syne:wght@600;700;800&display=swap');
+
+  /* ── Page wrapper ── */
+  .home-page {
+    --font-display: 'Syne', system-ui, sans-serif;
+    --accent: #eb5a37;
+    --accent-soft: rgba(235, 90, 55, 0.15);
+    --accent-glow: rgba(235, 90, 55, 0.4);
+    overflow: hidden;
+  }
+
+  /* ── Shared ── */
   .section {
-    padding: 5rem 1.5rem;
+    position: relative;
+    padding: 6rem 1.5rem;
   }
 
   .section-container {
@@ -323,142 +429,257 @@ const heroShowcase = [
     margin: 0 auto;
   }
 
-  .section-title {
-    font-size: 2rem;
-    font-weight: 700;
+  .section-header {
     text-align: center;
-    margin-bottom: 0.5rem;
+    margin-bottom: 3.5rem;
   }
 
-  .section-subtitle {
-    text-align: center;
+  .section-tag {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent);
+    background: var(--accent-soft);
+    border: 1px solid rgba(235, 90, 55, 0.2);
+    padding: 0.3rem 0.75rem;
+    border-radius: 100px;
+    margin-bottom: 1.25rem;
+  }
+
+  .section-tag-bright {
+    background: rgba(235, 90, 55, 0.2);
+    border-color: rgba(235, 90, 55, 0.35);
+  }
+
+  .section-header h2 {
+    font-family: var(--font-display);
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    line-height: 1.15;
+    margin-bottom: 0.75rem;
+  }
+
+  .section-header p {
     color: var(--color-text-secondary);
     font-size: 1.05rem;
-    margin-bottom: 3rem;
+    max-width: 500px;
+    margin: 0 auto;
   }
 
+  /* ── Buttons ── */
   .btn {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.7rem 1.5rem;
-    font-size: 0.95rem;
+    padding: 0.75rem 1.6rem;
+    font-size: 0.9rem;
     font-weight: 600;
     border-radius: 10px;
     text-decoration: none;
-    transition: transform 0.15s, box-shadow 0.15s, background 0.15s;
+    transition: all 0.2s ease;
+    cursor: pointer;
+    border: none;
   }
 
-  .btn:hover {
-    text-decoration: none;
-    transform: translateY(-1px);
-  }
+  .btn:hover { text-decoration: none; }
 
   .btn:focus-visible {
-    outline: 2px solid var(--color-primary);
+    outline: 2px solid var(--accent);
     outline-offset: 2px;
   }
 
   .btn-primary {
-    background: var(--color-primary);
+    background: var(--accent);
     color: #fff;
   }
 
   .btn-primary:hover {
     background: var(--color-primary-dark);
-    box-shadow: 0 4px 20px rgba(235, 90, 55, 0.3);
+    transform: translateY(-1px);
   }
 
-  .btn-secondary {
-    background: var(--color-bg-secondary);
+  .btn-glow {
+    box-shadow: 0 0 20px rgba(235, 90, 55, 0.25), 0 0 60px rgba(235, 90, 55, 0.08);
+  }
+
+  .btn-glow:hover {
+    box-shadow: 0 0 30px rgba(235, 90, 55, 0.4), 0 0 80px rgba(235, 90, 55, 0.12);
+  }
+
+  .btn-ghost {
+    background: rgba(255, 255, 255, 0.06);
     color: var(--color-text);
     border: 1px solid var(--color-border);
+    backdrop-filter: blur(8px);
   }
 
-  .btn-secondary:hover {
+  .btn-ghost:hover {
     border-color: var(--color-text-secondary);
+    background: rgba(255, 255, 255, 0.1);
+    transform: translateY(-1px);
   }
 
+  [data-theme='light'] .btn-ghost {
+    background: rgba(0, 0, 0, 0.03);
+  }
+
+  [data-theme='light'] .btn-ghost:hover {
+    background: rgba(0, 0, 0, 0.06);
+  }
+
+  /* ══════════════════════════════════════
+     HERO
+     ══════════════════════════════════════ */
   .hero {
     position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
-    padding: calc(var(--navbar-height) + 4rem) 1.5rem 0;
+    padding: calc(var(--navbar-height) + 5rem) 1.5rem 0;
+    min-height: 100vh;
     overflow: hidden;
   }
 
-  .hero-glow {
+  .hero-bg {
     position: absolute;
-    top: -20%;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 900px;
-    height: 700px;
-    background: radial-gradient(ellipse, rgba(235, 90, 55, 0.15) 0%, rgba(235, 90, 55, 0.05) 40%, transparent 70%);
+    inset: 0;
     pointer-events: none;
+    overflow: hidden;
   }
 
-  .hero-grid-pattern {
+  .hero-gradient-orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(100px);
+  }
+
+  .hero-orb-1 {
+    top: -15%;
+    left: 30%;
+    width: 600px;
+    height: 600px;
+    background: radial-gradient(circle, rgba(235, 90, 55, 0.2) 0%, transparent 70%);
+    animation: orb-drift-1 12s ease-in-out infinite;
+  }
+
+  .hero-orb-2 {
+    top: 10%;
+    right: 15%;
+    width: 400px;
+    height: 400px;
+    background: radial-gradient(circle, rgba(255, 138, 101, 0.12) 0%, transparent 70%);
+    animation: orb-drift-2 15s ease-in-out infinite;
+  }
+
+  @keyframes orb-drift-1 {
+    0%, 100% { transform: translate(0, 0) scale(1); }
+    33% { transform: translate(40px, 20px) scale(1.05); }
+    66% { transform: translate(-20px, -10px) scale(0.95); }
+  }
+
+  @keyframes orb-drift-2 {
+    0%, 100% { transform: translate(0, 0) scale(1); }
+    50% { transform: translate(-30px, 30px) scale(1.08); }
+  }
+
+  .hero-noise {
+    position: absolute;
+    inset: 0;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
+    background-size: 200px 200px;
+    opacity: 0.5;
+  }
+
+  [data-theme='dark'] .hero-noise {
+    opacity: 0.4;
+  }
+
+  .hero-grid {
     position: absolute;
     inset: 0;
     background-image:
-      linear-gradient(rgba(235, 90, 55, 0.03) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(235, 90, 55, 0.03) 1px, transparent 1px);
-    background-size: 60px 60px;
-    mask-image: radial-gradient(ellipse 60% 50% at 50% 30%, black 20%, transparent 70%);
-    -webkit-mask-image: radial-gradient(ellipse 60% 50% at 50% 30%, black 20%, transparent 70%);
-    pointer-events: none;
+      linear-gradient(rgba(235, 90, 55, 0.04) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(235, 90, 55, 0.04) 1px, transparent 1px);
+    background-size: 80px 80px;
+    mask-image: radial-gradient(ellipse 70% 50% at 50% 30%, black 10%, transparent 70%);
+    -webkit-mask-image: radial-gradient(ellipse 70% 50% at 50% 30%, black 10%, transparent 70%);
   }
 
   .hero-content {
     position: relative;
     text-align: center;
-    max-width: 700px;
+    max-width: 780px;
+    z-index: 1;
   }
 
   .hero-badge {
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
-    padding: 0.35rem 0.85rem;
-    font-size: 0.8rem;
+    gap: 0.5rem;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.78rem;
     font-weight: 600;
-    color: var(--color-primary);
-    background: rgba(235, 90, 55, 0.08);
-    border: 1px solid rgba(235, 90, 55, 0.15);
+    color: var(--accent);
+    background: var(--accent-soft);
+    border: 1px solid rgba(235, 90, 55, 0.2);
     border-radius: 100px;
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
+    animation: fade-in-down 0.6s ease 0.1s both;
   }
 
-  [data-theme='dark'] .hero-badge {
-    background: rgba(235, 90, 55, 0.12);
-    border-color: rgba(235, 90, 55, 0.2);
+  .hero-badge-dot {
+    width: 6px;
+    height: 6px;
+    background: var(--accent);
+    border-radius: 50%;
+    animation: pulse-dot 2s ease-in-out infinite;
+  }
+
+  @keyframes pulse-dot {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.5; transform: scale(1.3); }
   }
 
   .hero h1 {
-    font-size: clamp(2.75rem, 6vw, 4.5rem);
+    font-family: var(--font-display);
+    font-size: clamp(3rem, 7.5vw, 5.5rem);
     font-weight: 800;
-    line-height: 1.08;
-    letter-spacing: -0.03em;
-    margin-bottom: 1.25rem;
+    line-height: 1.0;
+    letter-spacing: -0.04em;
+    margin-bottom: 1.5rem;
+    animation: fade-in-up 0.7s ease 0.2s both;
   }
 
-  .hero-gradient {
-    background: linear-gradient(135deg, var(--color-primary) 0%, #ff8a65 50%, var(--color-primary) 100%);
+  .hero-line-1 {
+    display: block;
+    background: linear-gradient(135deg, var(--accent) 0%, #ff8a65 60%, #ffab91 100%);
     background-size: 200% auto;
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
+    animation: gradient-shift 6s ease infinite;
+  }
+
+  @keyframes gradient-shift {
+    0%, 100% { background-position: 0% center; }
+    50% { background-position: 100% center; }
+  }
+
+  .hero-line-2 {
+    display: block;
   }
 
   .hero-subtitle {
-    font-size: 1.15rem;
+    font-size: 1.2rem;
     color: var(--color-text-secondary);
-    line-height: 1.6;
-    max-width: 520px;
-    margin: 0 auto 2rem;
+    line-height: 1.7;
+    max-width: 480px;
+    margin: 0 auto 2.5rem;
+    animation: fade-in-up 0.7s ease 0.35s both;
   }
 
   .hero-actions {
@@ -466,44 +687,93 @@ const heroShowcase = [
     gap: 0.75rem;
     justify-content: center;
     flex-wrap: wrap;
+    animation: fade-in-up 0.7s ease 0.45s both;
   }
 
+  .hero-stats {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+    margin-top: 3rem;
+    animation: fade-in-up 0.7s ease 0.55s both;
+  }
+
+  .hero-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.15rem;
+  }
+
+  .hero-stat-value {
+    font-family: var(--font-display);
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: var(--color-text);
+  }
+
+  .hero-stat-label {
+    font-size: 0.72rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .hero-stat-divider {
+    width: 1px;
+    height: 28px;
+    background: var(--color-border);
+  }
+
+  /* Hero showcase */
   .hero-showcase {
     position: relative;
     width: 100%;
-    max-width: 1100px;
-    margin-top: 3.5rem;
-    perspective: 1200px;
+    max-width: 1200px;
+    margin-top: 4rem;
+    perspective: 1400px;
+    animation: fade-in-up 0.8s ease 0.6s both;
   }
 
   .hero-showcase-track {
     display: flex;
-    gap: 1rem;
+    gap: 1.25rem;
     justify-content: center;
-    transform: rotateX(4deg);
+    transform: rotateX(3deg);
     transform-origin: center bottom;
     padding: 0 1rem;
   }
 
   .hero-showcase-card {
     position: relative;
-    flex: 0 0 340px;
+    flex: 0 0 380px;
     aspect-ratio: 16 / 10;
-    border-radius: 12px;
+    border-radius: 14px;
     overflow: hidden;
-    border: 1px solid var(--color-border);
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.12), 0 4px 20px rgba(0, 0, 0, 0.06);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow:
+      0 25px 80px rgba(0, 0, 0, 0.12),
+      0 4px 20px rgba(0, 0, 0, 0.06),
+      inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    transition: transform 0.4s cubic-bezier(0.2, 0, 0, 1), box-shadow 0.4s ease;
     line-height: 0;
   }
 
   [data-theme='dark'] .hero-showcase-card {
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4), 0 4px 20px rgba(0, 0, 0, 0.2);
+    box-shadow:
+      0 25px 80px rgba(0, 0, 0, 0.5),
+      0 4px 20px rgba(0, 0, 0, 0.3),
+      inset 0 1px 0 rgba(255, 255, 255, 0.06);
   }
 
   .hero-showcase-card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 28px 70px rgba(0, 0, 0, 0.16), 0 8px 24px rgba(0, 0, 0, 0.08);
+    transform: translateY(-6px) scale(1.01);
+    box-shadow:
+      0 35px 100px rgba(0, 0, 0, 0.18),
+      0 8px 30px rgba(0, 0, 0, 0.08),
+      0 0 0 1px rgba(235, 90, 55, 0.15);
   }
 
   .hero-showcase-card :global(img) {
@@ -516,175 +786,332 @@ const heroShowcase = [
 
   .hero-showcase-label {
     position: absolute;
-    top: 0.6rem;
+    top: 0.75rem;
     left: 50%;
     transform: translateX(-50%);
-    font-size: 0.75rem;
-    font-weight: 600;
-    padding: 0.2rem 0.6rem;
-    background: rgba(0, 0, 0, 0.6);
-    backdrop-filter: blur(8px);
-    color: #fff;
-    border-radius: 6px;
-    line-height: 1.4;
+    font-family: var(--font-display);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 0.5rem 1rem;
+    background: linear-gradient(135deg, rgba(0, 0, 0, 0.75) 0%, rgba(30, 15, 10, 0.8) 100%);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    color: rgba(255, 255, 255, 0.95);
+    border-radius: 100px;
+    border: 1px solid rgba(235, 90, 55, 0.2);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.06);
     white-space: nowrap;
   }
 
-  .hero-showcase::after {
-    content: '';
+  .hero-showcase-fade {
     position: absolute;
     bottom: 0;
     left: 0;
     right: 0;
-    height: 50%;
-    background: linear-gradient(to bottom, transparent 0%, var(--color-bg) 90%);
+    height: 60%;
+    background: linear-gradient(to bottom, transparent 0%, var(--color-bg) 95%);
     pointer-events: none;
   }
 
+  /* ══════════════════════════════════════
+     THEMES
+     ══════════════════════════════════════ */
   .themes-section {
-    background: var(--color-bg-secondary);
+    padding-top: 2rem;
+    padding-bottom: 4rem;
   }
 
-  .bento-grid {
+  .themes-bento {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: auto auto auto;
+    grid-auto-rows: 200px;
     gap: 0.75rem;
-    margin-bottom: 2rem;
+    max-width: 1100px;
+    margin: 0 auto;
   }
 
-  .bento-item {
+  /* Layout: hero card spans 2 cols, tall card spans 2 rows */
+  .bento-1 { grid-column: span 2; grid-row: span 2; }
+  .bento-2 { grid-column: span 1; grid-row: span 1; }
+  .bento-3 { grid-column: span 1; grid-row: span 1; }
+  .bento-4 { grid-column: span 1; grid-row: span 1; }
+  .bento-5 { grid-column: span 1; grid-row: span 1; }
+  .bento-6 { grid-column: span 1; grid-row: span 1; }
+
+  .bento-card {
     position: relative;
     overflow: hidden;
-    border-radius: 12px;
+    border-radius: 14px;
     border: 1px solid var(--color-border);
+    background: var(--color-bg-secondary);
     line-height: 0;
+    cursor: default;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
   }
 
-  .bento-item :global(img) {
+  .bento-card:hover {
+    transform: translateY(-3px);
+    border-color: rgba(235, 90, 55, 0.3);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.1);
+  }
+
+  [data-theme='dark'] .bento-card:hover {
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+  }
+
+  .bento-card :global(img) {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    transition: transform 0.3s ease;
+    object-position: top left;
+    display: block;
+    transition: transform 0.5s cubic-bezier(0.2, 0, 0, 1);
   }
 
-  .bento-item:hover :global(img) {
-    transform: scale(1.02);
+  .bento-card:hover :global(img) {
+    transform: scale(1.03);
   }
 
-  .theme-label {
+  .bento-label {
     position: absolute;
-    bottom: 0.5rem;
-    left: 0.5rem;
+    bottom: 0.6rem;
+    left: 0.6rem;
     font-size: 0.75rem;
-    font-weight: 600;
-    padding: 0.2rem 0.5rem;
-    background: rgba(0, 0, 0, 0.6);
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    padding: 0.25rem 0.6rem;
+    background: rgba(0, 0, 0, 0.65);
     backdrop-filter: blur(8px);
     color: #fff;
     border-radius: 6px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
     line-height: 1.4;
   }
 
-  .bento-1 { grid-column: span 2; }
-  .bento-5 { grid-row: span 2; }
+  .bento-1 .bento-label {
+    font-size: 0.85rem;
+    padding: 0.3rem 0.75rem;
+    bottom: 0.75rem;
+    left: 0.75rem;
+  }
+
+  .themes-cta {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-top: 2.5rem;
+  }
 
   .browse-link {
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
     font-size: 0.9rem;
-    font-weight: 500;
-    color: var(--color-link);
+    font-weight: 600;
+    color: var(--accent);
     text-decoration: none;
+    transition: gap 0.2s ease;
   }
 
   .browse-link:hover {
-    text-decoration: underline;
+    text-decoration: none;
+    gap: 0.6rem;
   }
 
   .browse-link:focus-visible {
-    outline: 2px solid var(--color-primary);
+    outline: 2px solid var(--accent);
     outline-offset: 2px;
     border-radius: 4px;
   }
 
+  .themes-count {
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+    font-weight: 500;
+    padding-left: 1.25rem;
+    border-left: 1px solid var(--color-border);
+  }
+
+  /* ══════════════════════════════════════
+     FEATURES
+     ══════════════════════════════════════ */
+  .features-section {
+    background: var(--color-bg-secondary);
+  }
+
   .features-grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 1.25rem;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
   }
 
   .feature-card {
+    position: relative;
     display: flex;
     flex-direction: column;
     padding: 1.75rem;
-    border-radius: 12px;
+    border-radius: 14px;
     border: 1px solid var(--color-border);
     background: var(--color-bg);
     text-decoration: none;
     color: var(--color-text);
-    transition: transform 0.15s, border-color 0.15s, box-shadow 0.15s;
+    transition: all 0.25s ease;
+    overflow: hidden;
+  }
+
+  .feature-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(235, 90, 55, 0.04) 0%, transparent 50%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
   }
 
   .feature-card:hover {
-    transform: translateY(-2px);
-    border-color: var(--color-primary);
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
     text-decoration: none;
+    transform: translateY(-2px);
+    border-color: rgba(235, 90, 55, 0.3);
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.06);
+  }
+
+  .feature-card:hover::before {
+    opacity: 1;
   }
 
   .feature-card:focus-visible {
-    outline: 2px solid var(--color-primary);
+    outline: 2px solid var(--accent);
     outline-offset: 2px;
   }
 
   .feature-icon {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 44px;
-    height: 44px;
+    width: 42px;
+    height: 42px;
     border-radius: 10px;
-    background: rgba(235, 90, 55, 0.1);
-    color: var(--color-primary);
+    background: var(--accent-soft);
+    color: var(--accent);
     margin-bottom: 1rem;
   }
 
   .feature-card h3 {
+    position: relative;
+    font-family: var(--font-display);
     font-size: 1.1rem;
     font-weight: 700;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.4rem;
   }
 
   .feature-card p {
-    font-size: 0.9rem;
+    position: relative;
+    font-size: 0.88rem;
     color: var(--color-text-secondary);
-    line-height: 1.5;
+    line-height: 1.55;
     margin: 0;
   }
 
-  .install-block {
-    max-width: 640px;
-    margin: 0 auto;
-    border-radius: 12px;
+  .feature-arrow {
+    position: absolute;
+    top: 1.75rem;
+    right: 1.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--accent-soft);
+    color: var(--accent);
+    opacity: 0;
+    transform: translateX(-4px);
+    transition: opacity 0.25s, transform 0.25s;
+  }
+
+  .feature-card:hover .feature-arrow {
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  /* ══════════════════════════════════════
+     INSTALL
+     ══════════════════════════════════════ */
+  .install-section {
     overflow: hidden;
-    border: 1px solid var(--color-border);
-    background: #1a1a2e;
+    padding-top: 6rem;
+    padding-bottom: 6rem;
+  }
+
+  .install-bg {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  .install-orb {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 800px;
+    height: 600px;
+    background: radial-gradient(ellipse, rgba(235, 90, 55, 0.1) 0%, transparent 60%);
+  }
+
+  .install-noise {
+    position: absolute;
+    inset: 0;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
+    background-size: 200px 200px;
+    opacity: 0.3;
+  }
+
+  .install-container {
+    position: relative;
+  }
+
+  .install-title {
+    background: linear-gradient(135deg, var(--accent) 0%, #ff8a65 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .install-block {
+    max-width: 660px;
+    margin: 0 auto;
+    border-radius: 14px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: #0f0f1a;
+    box-shadow:
+      0 25px 80px rgba(0, 0, 0, 0.2),
+      0 0 0 1px rgba(255, 255, 255, 0.04),
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
   }
 
   .install-tabs {
     display: flex;
-    background: #151525;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(0, 0, 0, 0.3);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   }
 
   .install-tab {
     flex: 1;
-    padding: 0.6rem 1rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.65rem 1rem;
     border: none;
     background: none;
-    color: rgba(255, 255, 255, 0.5);
+    color: rgba(255, 255, 255, 0.4);
     font-size: 0.8rem;
     font-weight: 500;
     cursor: pointer;
@@ -693,36 +1120,49 @@ const heroShowcase = [
   }
 
   .install-tab:hover {
-    color: rgba(255, 255, 255, 0.8);
+    color: rgba(255, 255, 255, 0.7);
   }
 
   .install-tab.active {
     color: #fff;
-    box-shadow: inset 0 -2px 0 var(--color-primary);
+    box-shadow: inset 0 -2px 0 var(--accent);
   }
 
   .install-tab:focus-visible {
-    outline: 2px solid var(--color-primary);
+    outline: 2px solid var(--accent);
     outline-offset: -2px;
   }
 
   .install-panels {
     position: relative;
-    padding: 1.25rem 1.25rem;
+    padding: 1.25rem 1.5rem;
     padding-right: 3.5rem;
+    display: flex;
+    align-items: center;
   }
 
   .install-panel {
     display: none;
+    align-items: center;
+    gap: 0.75rem;
   }
 
   .install-panel.active {
-    display: block;
+    display: flex;
+  }
+
+  .install-prompt {
+    color: var(--accent);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    font-weight: 600;
+    user-select: none;
+    flex-shrink: 0;
   }
 
   .install-panel code {
     font-family: var(--font-mono);
-    font-size: 0.85rem;
+    font-size: 0.82rem;
     color: #e2e8f0;
     background: none;
     padding: 0;
@@ -732,67 +1172,30 @@ const heroShowcase = [
 
   .copy-btn {
     position: absolute;
-    top: 0.85rem;
+    top: 50%;
     right: 0.85rem;
+    transform: translateY(-50%);
     display: flex;
     align-items: center;
     justify-content: center;
     width: 32px;
     height: 32px;
     border: none;
-    background: rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.06);
     border-radius: 6px;
     cursor: pointer;
-    color: rgba(255, 255, 255, 0.5);
+    color: rgba(255, 255, 255, 0.4);
     transition: color 0.15s, background 0.15s;
   }
 
   .copy-btn:hover {
-    background: rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.12);
     color: #fff;
   }
 
   .copy-btn:focus-visible {
-    outline: 2px solid var(--color-primary);
+    outline: 2px solid var(--accent);
     outline-offset: 2px;
-  }
-
-  .browse-row {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    flex-wrap: wrap;
-  }
-
-  .browse-stat {
-    font-size: 0.8rem;
-    color: var(--color-text-secondary);
-    font-weight: 500;
-  }
-
-  .install-section {
-    position: relative;
-    overflow: hidden;
-    padding-top: 0;
-  }
-
-  .install-glow {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 700px;
-    height: 500px;
-    background: radial-gradient(ellipse, rgba(235, 90, 55, 0.1) 0%, transparent 70%);
-    pointer-events: none;
-  }
-
-  .install-section .section-container {
-    position: relative;
-  }
-
-  .install-title {
-    color: var(--color-primary);
   }
 
   .install-actions {
@@ -800,111 +1203,146 @@ const heroShowcase = [
     gap: 0.75rem;
     justify-content: center;
     flex-wrap: wrap;
-    margin-top: 2rem;
+    margin-top: 2.5rem;
   }
 
-  .section-subtitle + .section-subtitle-secondary {
-    margin-bottom: 3rem;
-    font-size: 0.95rem;
+  /* ── Animations ── */
+  @keyframes fade-in-up {
+    from { opacity: 0; transform: translateY(24px); }
+    to { opacity: 1; transform: translateY(0); }
   }
 
-  .section-subtitle:has(+ .section-subtitle-secondary) {
-    margin-bottom: 0.25rem;
+  @keyframes fade-in-down {
+    from { opacity: 0; transform: translateY(-12px); }
+    to { opacity: 1; transform: translateY(0); }
   }
 
   @media (prefers-reduced-motion: no-preference) {
-    .section-title,
-    .section-subtitle,
-    .bento-item,
-    .feature-card,
-    .install-block {
-      opacity: 0;
-      transform: translateY(20px);
-      animation: fade-in-up 0.5s ease forwards;
-    }
-
-    .hero-content {
-      opacity: 0;
-      transform: translateY(20px);
-      animation: fade-in-up 0.6s ease 0.1s forwards;
-    }
-
+    .hero-badge,
+    .hero h1,
+    .hero-subtitle,
+    .hero-actions,
+    .hero-stats,
     .hero-showcase {
-      opacity: 0;
-      transform: translateY(30px);
-      animation: fade-in-up 0.7s ease 0.25s forwards;
+      /* Animations defined inline above via animation property */
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hero-badge,
+    .hero h1,
+    .hero-subtitle,
+    .hero-actions,
+    .hero-stats,
+    .hero-showcase {
+      animation: none !important;
+      opacity: 1 !important;
     }
 
-    .bento-1 { animation-delay: 0.05s; }
-    .bento-2 { animation-delay: 0.1s; }
-    .bento-3 { animation-delay: 0.15s; }
-    .bento-4 { animation-delay: 0.2s; }
-    .bento-5 { animation-delay: 0.25s; }
-    .bento-6 { animation-delay: 0.3s; }
+    .hero-gradient-orb {
+      animation: none !important;
+    }
 
-    @keyframes fade-in-up {
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
+    .hero-line-1 {
+      animation: none !important;
+    }
+
+    .hero-badge-dot {
+      animation: none !important;
+    }
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 900px) {
+    .features-grid {
+      grid-template-columns: 1fr;
     }
   }
 
   @media (max-width: 768px) {
     .section {
-      padding: 3.5rem 1rem;
+      padding: 4rem 1rem;
     }
 
     .hero {
-      padding: calc(var(--navbar-height) + 2.5rem) 1rem 0;
+      padding: calc(var(--navbar-height) + 3rem) 1rem 0;
+      min-height: auto;
     }
 
     .hero h1 {
-      font-size: 2.25rem;
+      font-size: 2.5rem;
     }
 
     .hero-subtitle {
       font-size: 1rem;
     }
 
+    .hero-stats {
+      gap: 1rem;
+    }
+
+    .hero-stat-value {
+      font-size: 1.1rem;
+    }
+
     .hero-showcase {
-      margin-top: 2.5rem;
+      margin-top: 3rem;
     }
 
     .hero-showcase-track {
       transform: rotateX(2deg);
-      gap: 0.6rem;
+      gap: 0.75rem;
       padding: 0 0.5rem;
     }
 
     .hero-showcase-card {
-      flex: 0 0 260px;
+      flex: 0 0 280px;
     }
 
-    .bento-grid {
+    .themes-bento {
       grid-template-columns: repeat(2, 1fr);
-      grid-template-rows: auto;
+      grid-auto-rows: 160px;
     }
 
-    .bento-1 { grid-column: span 2; }
+    .bento-1 { grid-column: span 2; grid-row: span 2; }
     .bento-5 { grid-row: span 1; }
 
-    .features-grid {
-      grid-template-columns: 1fr;
-      gap: 1rem;
+    .section-header h2 {
+      font-size: 1.6rem;
     }
 
-    .section-title {
-      font-size: 1.5rem;
+    .themes-count {
+      border-left: none;
+      padding-left: 0;
+    }
+
+    .install-section {
+      padding-top: 4rem;
+      padding-bottom: 4rem;
     }
   }
 
   @media (max-width: 480px) {
-    .bento-grid {
-      grid-template-columns: 1fr 1fr;
+    .hero h1 {
+      font-size: 2rem;
     }
 
-    .bento-1 { grid-column: span 2; }
-    .bento-5 { grid-row: span 1; }
+    .hero-showcase-card {
+      flex: 0 0 240px;
+    }
+
+    .hero-stats {
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .hero-stat-divider {
+      display: none;
+    }
+
+    .hero-stat {
+      flex-direction: row;
+      gap: 0.5rem;
+    }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,4 @@
 ---
-import { Image } from 'astro:assets';
 import theme1 from '../assets/homepage/1.png';
 import theme2 from '../assets/homepage/2.png';
 import theme3 from '../assets/homepage/3.png';
@@ -9,8 +8,10 @@ import theme6 from '../assets/homepage/6.png';
 import heroFullApp from '../assets/homepage/full-app-display.png';
 import heroLyrics from '../assets/homepage/lyrics-plus.png';
 import heroMarketplace from '../assets/homepage/marketplace.png';
-import DiscordIcon from '../components/icons/DiscordIcon.astro';
-import GitHubIcon from '../components/icons/GitHubIcon.astro';
+import FeaturesGrid from '../components/homepage/FeaturesGrid.astro';
+import HeroSection from '../components/homepage/HeroSection.astro';
+import InstallSection from '../components/homepage/InstallSection.astro';
+import ThemesBento from '../components/homepage/ThemesBento.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
 
 // Community stats — update these periodically
@@ -108,333 +109,43 @@ const features = [
 
 <BaseLayout title="Spicetify" description="Powerful CLI tool to take control of the Spotify client.">
   <div class="home-page">
-    <!-- HERO -->
-    <section id="hero" class="hero">
-      <div class="hero-bg">
-        <div class="hero-gradient-orb hero-orb-1"></div>
-        <div class="hero-gradient-orb hero-orb-2"></div>
-        <div class="hero-noise"></div>
-        <div class="hero-grid"></div>
-      </div>
-
-      <div class="hero-content">
-        <div class="hero-badge">
-          <span class="hero-badge-dot"></span>
-          Open Source &middot; {stats.githubStars} Stars &middot; {stats.downloads} Downloads
-        </div>
-
-        <h1>
-          <span class="hero-line-1">Make Spotify</span>
-          <span class="hero-line-2">truly yours.</span>
-        </h1>
-
-        <p class="hero-subtitle">
-          Themes. Extensions. Custom apps.<br />
-          The ultimate Spotify customization toolkit.
-        </p>
-
-        <div class="hero-actions">
-          <a href="#install" class="btn btn-primary btn-glow">
-            Get Started
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></svg>
-          </a>
-          <a
-            href="https://github.com/spicetify/cli"
-            class="btn btn-ghost"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <GitHubIcon />
-            View on GitHub
-          </a>
-        </div>
-      </div>
-
-      <div class="hero-showcase">
-        <div class="hero-showcase-track">
-          {heroShowcase.map((item) => (
-            <div class="hero-showcase-card">
-              <Image
-                src={item.src}
-                alt={item.alt}
-                widths={[600, 900, 1400]}
-                sizes="(max-width: 768px) 300px, 500px"
-                format="webp"
-                quality={90}
-                loading="eager"
-              />
-              <span class="hero-showcase-label">{item.label}</span>
-            </div>
-          ))}
-        </div>
-        <div class="hero-showcase-fade"></div>
-      </div>
-    </section>
-
-    <!-- THEMES -->
-    <section id="themes" class="section themes-section">
-      <div class="section-header">
-        <span class="section-tag">Showcase</span>
-        <h2>Themes for every taste</h2>
-        <p>Browse community-made themes that completely transform Spotify.</p>
-      </div>
-
-      <div class="themes-bento">
-        {themes.map((theme, i) => (
-          <div class:list={['bento-card', `bento-${i + 1}`]}>
-            <Image
-              src={theme.src}
-              alt={theme.alt}
-              widths={[600, 900, 1400]}
-              sizes={`(max-width: 768px) 90vw, ${i === 0 ? '66vw' : '33vw'}`}
-              format="webp"
-              quality={90}
-              loading="lazy"
-            />
-            <span class="bento-label">{theme.label}</span>
-          </div>
-        ))}
-      </div>
-
-      <div class="themes-cta">
-        <a href="/docs/customization/themes" class="browse-link">
-          Browse all themes
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></svg>
-        </a>
-        <span class="themes-count">{stats.marketplaceItems} items in the Marketplace</span>
-      </div>
-    </section>
-
-    <!-- FEATURES -->
-    <section id="features" class="section features-section">
-      <div class="section-container">
-        <div class="section-header">
-          <span class="section-tag">Features</span>
-          <h2>Everything you need</h2>
-          <p>A complete toolkit to customize every corner of Spotify.</p>
-        </div>
-
-        <div class="features-grid">
-          {features.map((feature) => (
-            <a href={feature.href} class="feature-card">
-              <div class="feature-icon" data-icon={feature.icon}>
-                {feature.icon === 'palette' && (
-                  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                    <circle cx="13.5" cy="6.5" r="2.5" /><circle cx="17.5" cy="10.5" r="2.5" /><circle cx="8.5" cy="7.5" r="2.5" /><circle cx="6.5" cy="12.5" r="2.5" />
-                    <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
-                  </svg>
-                )}
-                {feature.icon === 'puzzle' && (
-                  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                    <path d="M12 2v4m0 12v4M2 12h4m12 0h4m-3.17-6.83-2.83 2.83m-4 4-2.83 2.83M6.83 5.17l2.83 2.83m4 4 2.83 2.83" />
-                  </svg>
-                )}
-                {feature.icon === 'grid' && (
-                  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                    <rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" /><rect x="3" y="14" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" />
-                  </svg>
-                )}
-                {feature.icon === 'terminal' && (
-                  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                    <polyline points="4 17 10 11 4 5" /><line x1="12" y1="19" x2="20" y2="19" />
-                  </svg>
-                )}
-              </div>
-              <h3>{feature.title}</h3>
-              <p>{feature.description}</p>
-              <span class="feature-arrow">
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></svg>
-              </span>
-            </a>
-          ))}
-        </div>
-      </div>
-    </section>
-
-    <!-- INSTALL -->
-    <section id="install" class="section install-section">
-      <div class="install-bg">
-        <div class="install-orb"></div>
-        <div class="install-noise"></div>
-      </div>
-      <div class="section-container install-container">
-        <div class="section-header">
-          <span class="section-tag section-tag-bright">Quick Start</span>
-          <h2 class="install-title">Install in seconds</h2>
-          <p>One command. That's it.</p>
-        </div>
-
-        <div class="install-block">
-          <div class="install-tabs" role="tablist">
-            <button role="tab" aria-selected="true" aria-controls="panel-windows" id="tab-windows" class="install-tab active">
-              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/></svg>
-              Windows
-            </button>
-            <button role="tab" aria-selected="false" aria-controls="panel-macos" id="tab-macos" class="install-tab">
-              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm0 1.5a8.5 8.5 0 110 17 8.5 8.5 0 010-17zm-1 3.5v4H7v1h4v4h1v-4h4v-1h-4V7h-1z"/></svg>
-              macOS / Linux
-            </button>
-          </div>
-          <div class="install-panels">
-            <div role="tabpanel" id="panel-windows" aria-labelledby="tab-windows" class="install-panel active">
-              <span class="install-prompt">$</span>
-              <code>iwr -useb https://raw.githubusercontent.com/spicetify/cli/main/install.ps1 | iex</code>
-            </div>
-            <div role="tabpanel" id="panel-macos" aria-labelledby="tab-macos" class="install-panel" hidden>
-              <span class="install-prompt">$</span>
-              <code>curl -fsSL https://raw.githubusercontent.com/spicetify/cli/main/install.sh | sh</code>
-            </div>
-            <button class="copy-btn" aria-label="Copy command to clipboard" title="Copy to clipboard">
-              <svg class="icon-copy" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-              </svg>
-              <svg class="icon-check" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none">
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-            </button>
-          </div>
-        </div>
-
-        <div class="install-actions">
-          <a href="/docs/getting-started" class="btn btn-primary btn-glow">
-            Read the Docs
-          </a>
-          <a
-            href="https://discord.gg/VnevqPp2Rr"
-            class="btn btn-ghost"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <DiscordIcon />
-            Join Discord
-          </a>
-        </div>
-      </div>
-    </section>
+    <HeroSection stats={stats} heroShowcase={heroShowcase} />
+    <ThemesBento themes={themes} marketplaceItems={stats.marketplaceItems} />
+    <FeaturesGrid features={features} />
+    <InstallSection />
   </div>
 </BaseLayout>
 
-<script is:inline>
-  (function () {
-    function setupInstallTabs() {
-      var tabs = document.querySelectorAll('.install-tab');
-      var panels = document.querySelectorAll('.install-panel');
-
-      function activateTab(tab) {
-        tabs.forEach(function (t) {
-          t.classList.remove('active');
-          t.setAttribute('aria-selected', 'false');
-        });
-        panels.forEach(function (p) {
-          p.classList.remove('active');
-          p.hidden = true;
-        });
-
-        tab.classList.add('active');
-        tab.setAttribute('aria-selected', 'true');
-        var panelId = tab.getAttribute('aria-controls');
-        var panel = document.getElementById(panelId);
-        if (panel) {
-          panel.classList.add('active');
-          panel.hidden = false;
-        }
-      }
-
-      // Auto-select based on OS
-      var ua = navigator.userAgent.toLowerCase();
-      if (ua.includes('mac') || ua.includes('linux')) {
-        var macTab = document.getElementById('tab-macos');
-        if (macTab) activateTab(macTab);
-      }
-
-      tabs.forEach(function (tab) {
-        tab.addEventListener('click', function () {
-          activateTab(tab);
-        });
-      });
-    }
-
-    function setupCopyButton() {
-      var btn = document.querySelector('.copy-btn');
-      if (!btn) return;
-
-      btn.addEventListener('click', function () {
-        var activePanel = document.querySelector('.install-panel.active');
-        if (!activePanel) return;
-        var code = activePanel.querySelector('code');
-        if (!code) return;
-
-        var iconCopy = btn.querySelector('.icon-copy');
-        var iconCheck = btn.querySelector('.icon-check');
-
-        navigator.clipboard.writeText(code.textContent.trim()).then(function () {
-          iconCopy.style.display = 'none';
-          iconCheck.style.display = 'block';
-          setTimeout(function () {
-            iconCopy.style.display = 'block';
-            iconCheck.style.display = 'none';
-          }, 2000);
-        }).catch(function () {
-          var range = document.createRange();
-          range.selectNodeContents(code);
-          var sel = window.getSelection();
-          sel.removeAllRanges();
-          sel.addRange(range);
-        });
-      });
-    }
-
-    // Scroll-triggered reveal animations
-    function setupScrollReveal() {
-      var observer = new IntersectionObserver(function (entries) {
-        entries.forEach(function (entry) {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('revealed');
-            observer.unobserve(entry.target);
-          }
-        });
-      }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
-
-      document.querySelectorAll('.reveal-on-scroll').forEach(function (el) {
-        observer.observe(el);
-      });
-    }
-
-    setupInstallTabs();
-    setupCopyButton();
-    setupScrollReveal();
-  })();
-</script>
-
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Syne:wght@600;700;800&display=swap');
-
-  /* ── Page wrapper ── */
   .home-page {
     --font-display: 'Syne', system-ui, sans-serif;
-    --accent: #eb5a37;
+    --accent: var(--color-primary);
     --accent-soft: rgba(235, 90, 55, 0.15);
     --accent-glow: rgba(235, 90, 55, 0.4);
+    --accent-border: rgba(235, 90, 55, 0.2);
+    --accent-border-hover: rgba(235, 90, 55, 0.3);
+    --accent-subtle: rgba(235, 90, 55, 0.04);
+    --noise-bg: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
     overflow: hidden;
   }
 
-  /* ── Shared ── */
-  .section {
+  /* ── Shared section styles ── */
+  .home-page :global(.section) {
     position: relative;
     padding: 6rem 1.5rem;
   }
 
-  .section-container {
+  .home-page :global(.section-container) {
     max-width: 1100px;
     margin: 0 auto;
   }
 
-  .section-header {
+  .home-page :global(.section-header) {
     text-align: center;
     margin-bottom: 3.5rem;
   }
 
-  .section-tag {
+  .home-page :global(.section-tag) {
     display: inline-block;
     font-family: var(--font-mono);
     font-size: 0.7rem;
@@ -443,18 +154,18 @@ const features = [
     text-transform: uppercase;
     color: var(--accent);
     background: var(--accent-soft);
-    border: 1px solid rgba(235, 90, 55, 0.2);
+    border: 1px solid var(--accent-border);
     padding: 0.3rem 0.75rem;
     border-radius: 100px;
     margin-bottom: 1.25rem;
   }
 
-  .section-tag-bright {
+  .home-page :global(.section-tag-bright) {
     background: rgba(235, 90, 55, 0.2);
     border-color: rgba(235, 90, 55, 0.35);
   }
 
-  .section-header h2 {
+  .home-page :global(.section-header h2) {
     font-family: var(--font-display);
     font-size: clamp(1.75rem, 4vw, 2.5rem);
     font-weight: 800;
@@ -463,15 +174,15 @@ const features = [
     margin-bottom: 0.75rem;
   }
 
-  .section-header p {
+  .home-page :global(.section-header p) {
     color: var(--color-text-secondary);
     font-size: 1.05rem;
     max-width: 500px;
     margin: 0 auto;
   }
 
-  /* ── Buttons ── */
-  .btn {
+  /* ── Shared button styles ── */
+  .home-page :global(.btn) {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
@@ -480,869 +191,69 @@ const features = [
     font-weight: 600;
     border-radius: 10px;
     text-decoration: none;
-    transition: all 0.2s ease;
+    transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
     cursor: pointer;
     border: none;
   }
 
-  .btn:hover { text-decoration: none; }
+  .home-page :global(.btn:hover) { text-decoration: none; }
 
-  .btn:focus-visible {
+  .home-page :global(.btn:focus-visible) {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
   }
 
-  .btn-primary {
+  .home-page :global(.btn-primary) {
     background: var(--accent);
     color: #fff;
   }
 
-  .btn-primary:hover {
+  .home-page :global(.btn-primary:hover) {
     background: var(--color-primary-dark);
     transform: translateY(-1px);
   }
 
-  .btn-glow {
+  .home-page :global(.btn-glow) {
     box-shadow: 0 0 20px rgba(235, 90, 55, 0.25), 0 0 60px rgba(235, 90, 55, 0.08);
   }
 
-  .btn-glow:hover {
-    box-shadow: 0 0 30px rgba(235, 90, 55, 0.4), 0 0 80px rgba(235, 90, 55, 0.12);
+  .home-page :global(.btn-glow:hover) {
+    box-shadow: 0 0 30px var(--accent-glow), 0 0 80px rgba(235, 90, 55, 0.12);
   }
 
-  .btn-ghost {
+  .home-page :global(.btn-ghost) {
     background: rgba(255, 255, 255, 0.06);
     color: var(--color-text);
     border: 1px solid var(--color-border);
-    backdrop-filter: blur(8px);
   }
 
-  .btn-ghost:hover {
+  .home-page :global(.btn-ghost:hover) {
     border-color: var(--color-text-secondary);
     background: rgba(255, 255, 255, 0.1);
     transform: translateY(-1px);
   }
 
-  [data-theme='light'] .btn-ghost {
+  [data-theme='light'] .home-page :global(.btn-ghost) {
     background: rgba(0, 0, 0, 0.03);
   }
 
-  [data-theme='light'] .btn-ghost:hover {
+  [data-theme='light'] .home-page :global(.btn-ghost:hover) {
     background: rgba(0, 0, 0, 0.06);
   }
 
-  /* ══════════════════════════════════════
-     HERO
-     ══════════════════════════════════════ */
-  .hero {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: calc(var(--navbar-height) + 5rem) 1.5rem 0;
-    min-height: 100vh;
-    overflow: hidden;
-  }
-
-  .hero-bg {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    overflow: hidden;
-  }
-
-  .hero-gradient-orb {
-    position: absolute;
-    border-radius: 50%;
-    filter: blur(100px);
-  }
-
-  .hero-orb-1 {
-    top: -15%;
-    left: 30%;
-    width: 600px;
-    height: 600px;
-    background: radial-gradient(circle, rgba(235, 90, 55, 0.2) 0%, transparent 70%);
-    animation: orb-drift-1 12s ease-in-out infinite;
-  }
-
-  .hero-orb-2 {
-    top: 10%;
-    right: 15%;
-    width: 400px;
-    height: 400px;
-    background: radial-gradient(circle, rgba(255, 138, 101, 0.12) 0%, transparent 70%);
-    animation: orb-drift-2 15s ease-in-out infinite;
-  }
-
-  @keyframes orb-drift-1 {
-    0%, 100% { transform: translate(0, 0) scale(1); }
-    33% { transform: translate(40px, 20px) scale(1.05); }
-    66% { transform: translate(-20px, -10px) scale(0.95); }
-  }
-
-  @keyframes orb-drift-2 {
-    0%, 100% { transform: translate(0, 0) scale(1); }
-    50% { transform: translate(-30px, 30px) scale(1.08); }
-  }
-
-  .hero-noise {
-    position: absolute;
-    inset: 0;
-    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
-    background-size: 200px 200px;
-    opacity: 0.5;
-  }
-
-  [data-theme='dark'] .hero-noise {
-    opacity: 0.4;
-  }
-
-  .hero-grid {
-    position: absolute;
-    inset: 0;
-    background-image:
-      linear-gradient(rgba(235, 90, 55, 0.04) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(235, 90, 55, 0.04) 1px, transparent 1px);
-    background-size: 80px 80px;
-    mask-image: radial-gradient(ellipse 70% 50% at 50% 30%, black 10%, transparent 70%);
-    -webkit-mask-image: radial-gradient(ellipse 70% 50% at 50% 30%, black 10%, transparent 70%);
-  }
-
-  .hero-content {
-    position: relative;
-    text-align: center;
-    max-width: 780px;
-    z-index: 1;
-  }
-
-  .hero-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.35rem 0.9rem;
-    font-size: 0.78rem;
-    font-weight: 600;
-    color: var(--accent);
-    background: var(--accent-soft);
-    border: 1px solid rgba(235, 90, 55, 0.2);
-    border-radius: 100px;
-    margin-bottom: 2rem;
-    animation: fade-in-down 0.6s ease 0.1s both;
-  }
-
-  .hero-badge-dot {
-    width: 6px;
-    height: 6px;
-    background: var(--accent);
-    border-radius: 50%;
-    animation: pulse-dot 2s ease-in-out infinite;
-  }
-
-  @keyframes pulse-dot {
-    0%, 100% { opacity: 1; transform: scale(1); }
-    50% { opacity: 0.5; transform: scale(1.3); }
-  }
-
-  .hero h1 {
-    font-family: var(--font-display);
-    font-size: clamp(3rem, 7.5vw, 5.5rem);
-    font-weight: 800;
-    line-height: 1.0;
-    letter-spacing: -0.04em;
-    margin-bottom: 1.5rem;
-    animation: fade-in-up 0.7s ease 0.2s both;
-  }
-
-  .hero-line-1 {
-    display: block;
-    background: linear-gradient(135deg, var(--accent) 0%, #ff8a65 60%, #ffab91 100%);
-    background-size: 200% auto;
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-    animation: gradient-shift 6s ease infinite;
-  }
-
-  @keyframes gradient-shift {
-    0%, 100% { background-position: 0% center; }
-    50% { background-position: 100% center; }
-  }
-
-  .hero-line-2 {
-    display: block;
-  }
-
-  .hero-subtitle {
-    font-size: 1.2rem;
-    color: var(--color-text-secondary);
-    line-height: 1.7;
-    max-width: 480px;
-    margin: 0 auto 2.5rem;
-    animation: fade-in-up 0.7s ease 0.35s both;
-  }
-
-  .hero-actions {
-    display: flex;
-    gap: 0.75rem;
-    justify-content: center;
-    flex-wrap: wrap;
-    animation: fade-in-up 0.7s ease 0.45s both;
-  }
-
-  .hero-stats {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 1.5rem;
-    margin-top: 3rem;
-    animation: fade-in-up 0.7s ease 0.55s both;
-  }
-
-  .hero-stat {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.15rem;
-  }
-
-  .hero-stat-value {
-    font-family: var(--font-display);
-    font-size: 1.3rem;
-    font-weight: 700;
-    color: var(--color-text);
-  }
-
-  .hero-stat-label {
-    font-size: 0.72rem;
-    font-weight: 500;
-    color: var(--color-text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-
-  .hero-stat-divider {
-    width: 1px;
-    height: 28px;
-    background: var(--color-border);
-  }
-
-  /* Hero showcase */
-  .hero-showcase {
-    position: relative;
-    width: 100%;
-    max-width: 1200px;
-    margin-top: 4rem;
-    perspective: 1400px;
-    animation: fade-in-up 0.8s ease 0.6s both;
-  }
-
-  .hero-showcase-track {
-    display: flex;
-    gap: 1.25rem;
-    justify-content: center;
-    transform: rotateX(3deg);
-    transform-origin: center bottom;
-    padding: 0 1rem;
-  }
-
-  .hero-showcase-card {
-    position: relative;
-    flex: 0 0 380px;
-    aspect-ratio: 16 / 10;
-    border-radius: 14px;
-    overflow: hidden;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    box-shadow:
-      0 25px 80px rgba(0, 0, 0, 0.12),
-      0 4px 20px rgba(0, 0, 0, 0.06),
-      inset 0 1px 0 rgba(255, 255, 255, 0.05);
-    transition: transform 0.4s cubic-bezier(0.2, 0, 0, 1), box-shadow 0.4s ease;
-    line-height: 0;
-  }
-
-  [data-theme='dark'] .hero-showcase-card {
-    box-shadow:
-      0 25px 80px rgba(0, 0, 0, 0.5),
-      0 4px 20px rgba(0, 0, 0, 0.3),
-      inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  }
-
-  .hero-showcase-card:hover {
-    transform: translateY(-6px) scale(1.01);
-    box-shadow:
-      0 35px 100px rgba(0, 0, 0, 0.18),
-      0 8px 30px rgba(0, 0, 0, 0.08),
-      0 0 0 1px rgba(235, 90, 55, 0.15);
-  }
-
-  .hero-showcase-card :global(img) {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    object-position: top left;
-    display: block;
-  }
-
-  .hero-showcase-label {
-    position: absolute;
-    top: 0.75rem;
-    left: 50%;
-    transform: translateX(-50%);
-    font-family: var(--font-display);
-    font-size: 0.7rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    padding: 0.5rem 1rem;
-    background: linear-gradient(135deg, rgba(0, 0, 0, 0.75) 0%, rgba(30, 15, 10, 0.8) 100%);
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
-    color: rgba(255, 255, 255, 0.95);
-    border-radius: 100px;
-    border: 1px solid rgba(235, 90, 55, 0.2);
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.06);
-    white-space: nowrap;
-  }
-
-  .hero-showcase-fade {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: 60%;
-    background: linear-gradient(to bottom, transparent 0%, var(--color-bg) 95%);
-    pointer-events: none;
-  }
-
-  /* ══════════════════════════════════════
-     THEMES
-     ══════════════════════════════════════ */
-  .themes-section {
-    padding-top: 2rem;
-    padding-bottom: 4rem;
-  }
-
-  .themes-bento {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-auto-rows: 200px;
-    gap: 0.75rem;
-    max-width: 1100px;
-    margin: 0 auto;
-  }
-
-  /* Layout: hero card spans 2 cols, tall card spans 2 rows */
-  .bento-1 { grid-column: span 2; grid-row: span 2; }
-  .bento-2 { grid-column: span 1; grid-row: span 1; }
-  .bento-3 { grid-column: span 1; grid-row: span 1; }
-  .bento-4 { grid-column: span 1; grid-row: span 1; }
-  .bento-5 { grid-column: span 1; grid-row: span 1; }
-  .bento-6 { grid-column: span 1; grid-row: span 1; }
-
-  .bento-card {
-    position: relative;
-    overflow: hidden;
-    border-radius: 14px;
-    border: 1px solid var(--color-border);
-    background: var(--color-bg-secondary);
-    line-height: 0;
-    cursor: default;
-    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
-  }
-
-  .bento-card:hover {
-    transform: translateY(-3px);
-    border-color: rgba(235, 90, 55, 0.3);
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.1);
-  }
-
-  [data-theme='dark'] .bento-card:hover {
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
-  }
-
-  .bento-card :global(img) {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    object-position: top left;
-    display: block;
-    transition: transform 0.5s cubic-bezier(0.2, 0, 0, 1);
-  }
-
-  .bento-card:hover :global(img) {
-    transform: scale(1.03);
-  }
-
-  .bento-label {
-    position: absolute;
-    bottom: 0.6rem;
-    left: 0.6rem;
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.02em;
-    padding: 0.25rem 0.6rem;
-    background: rgba(0, 0, 0, 0.65);
-    backdrop-filter: blur(8px);
-    color: #fff;
-    border-radius: 6px;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    line-height: 1.4;
-  }
-
-  .bento-1 .bento-label {
-    font-size: 0.85rem;
-    padding: 0.3rem 0.75rem;
-    bottom: 0.75rem;
-    left: 0.75rem;
-  }
-
-  .themes-cta {
-    display: flex;
-    align-items: center;
-    gap: 1.25rem;
-    justify-content: center;
-    flex-wrap: wrap;
-    margin-top: 2.5rem;
-  }
-
-  .browse-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--accent);
-    text-decoration: none;
-    transition: gap 0.2s ease;
-  }
-
-  .browse-link:hover {
-    text-decoration: none;
-    gap: 0.6rem;
-  }
-
-  .browse-link:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-    border-radius: 4px;
-  }
-
-  .themes-count {
-    font-size: 0.8rem;
-    color: var(--color-text-secondary);
-    font-weight: 500;
-    padding-left: 1.25rem;
-    border-left: 1px solid var(--color-border);
-  }
-
-  /* ══════════════════════════════════════
-     FEATURES
-     ══════════════════════════════════════ */
-  .features-section {
-    background: var(--color-bg-secondary);
-  }
-
-  .features-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1rem;
-  }
-
-  .feature-card {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    padding: 1.75rem;
-    border-radius: 14px;
-    border: 1px solid var(--color-border);
-    background: var(--color-bg);
-    text-decoration: none;
-    color: var(--color-text);
-    transition: all 0.25s ease;
-    overflow: hidden;
-  }
-
-  .feature-card::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(235, 90, 55, 0.04) 0%, transparent 50%);
-    opacity: 0;
-    transition: opacity 0.3s ease;
-  }
-
-  .feature-card:hover {
-    text-decoration: none;
-    transform: translateY(-2px);
-    border-color: rgba(235, 90, 55, 0.3);
-    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.06);
-  }
-
-  .feature-card:hover::before {
-    opacity: 1;
-  }
-
-  .feature-card:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
-
-  .feature-icon {
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 42px;
-    height: 42px;
-    border-radius: 10px;
-    background: var(--accent-soft);
-    color: var(--accent);
-    margin-bottom: 1rem;
-  }
-
-  .feature-card h3 {
-    position: relative;
-    font-family: var(--font-display);
-    font-size: 1.1rem;
-    font-weight: 700;
-    margin-bottom: 0.4rem;
-  }
-
-  .feature-card p {
-    position: relative;
-    font-size: 0.88rem;
-    color: var(--color-text-secondary);
-    line-height: 1.55;
-    margin: 0;
-  }
-
-  .feature-arrow {
-    position: absolute;
-    top: 1.75rem;
-    right: 1.75rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    background: var(--accent-soft);
-    color: var(--accent);
-    opacity: 0;
-    transform: translateX(-4px);
-    transition: opacity 0.25s, transform 0.25s;
-  }
-
-  .feature-card:hover .feature-arrow {
-    opacity: 1;
-    transform: translateX(0);
-  }
-
-  /* ══════════════════════════════════════
-     INSTALL
-     ══════════════════════════════════════ */
-  .install-section {
-    overflow: hidden;
-    padding-top: 6rem;
-    padding-bottom: 6rem;
-  }
-
-  .install-bg {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-  }
-
-  .install-orb {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 800px;
-    height: 600px;
-    background: radial-gradient(ellipse, rgba(235, 90, 55, 0.1) 0%, transparent 60%);
-  }
-
-  .install-noise {
-    position: absolute;
-    inset: 0;
-    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
-    background-size: 200px 200px;
-    opacity: 0.3;
-  }
-
-  .install-container {
-    position: relative;
-  }
-
-  .install-title {
-    background: linear-gradient(135deg, var(--accent) 0%, #ff8a65 100%);
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-  }
-
-  .install-block {
-    max-width: 660px;
-    margin: 0 auto;
-    border-radius: 14px;
-    overflow: hidden;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    background: #0f0f1a;
-    box-shadow:
-      0 25px 80px rgba(0, 0, 0, 0.2),
-      0 0 0 1px rgba(255, 255, 255, 0.04),
-      inset 0 1px 0 rgba(255, 255, 255, 0.04);
-  }
-
-  .install-tabs {
-    display: flex;
-    background: rgba(0, 0, 0, 0.3);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-  }
-
-  .install-tab {
-    flex: 1;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.4rem;
-    padding: 0.65rem 1rem;
-    border: none;
-    background: none;
-    color: rgba(255, 255, 255, 0.4);
-    font-size: 0.8rem;
-    font-weight: 500;
-    cursor: pointer;
-    font-family: var(--font-sans);
-    transition: color 0.15s;
-  }
-
-  .install-tab:hover {
-    color: rgba(255, 255, 255, 0.7);
-  }
-
-  .install-tab.active {
-    color: #fff;
-    box-shadow: inset 0 -2px 0 var(--accent);
-  }
-
-  .install-tab:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: -2px;
-  }
-
-  .install-panels {
-    position: relative;
-    padding: 1.25rem 1.5rem;
-    padding-right: 3.5rem;
-    display: flex;
-    align-items: center;
-  }
-
-  .install-panel {
-    display: none;
-    align-items: center;
-    gap: 0.75rem;
-  }
-
-  .install-panel.active {
-    display: flex;
-  }
-
-  .install-prompt {
-    color: var(--accent);
-    font-family: var(--font-mono);
-    font-size: 0.85rem;
-    font-weight: 600;
-    user-select: none;
-    flex-shrink: 0;
-  }
-
-  .install-panel code {
-    font-family: var(--font-mono);
-    font-size: 0.82rem;
-    color: #e2e8f0;
-    background: none;
-    padding: 0;
-    word-break: break-all;
-    line-height: 1.6;
-  }
-
-  .copy-btn {
-    position: absolute;
-    top: 50%;
-    right: 0.85rem;
-    transform: translateY(-50%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    border: none;
-    background: rgba(255, 255, 255, 0.06);
-    border-radius: 6px;
-    cursor: pointer;
-    color: rgba(255, 255, 255, 0.4);
-    transition: color 0.15s, background 0.15s;
-  }
-
-  .copy-btn:hover {
-    background: rgba(255, 255, 255, 0.12);
-    color: #fff;
-  }
-
-  .copy-btn:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
-
-  .install-actions {
-    display: flex;
-    gap: 0.75rem;
-    justify-content: center;
-    flex-wrap: wrap;
-    margin-top: 2.5rem;
-  }
-
-  /* ── Animations ── */
-  @keyframes fade-in-up {
-    from { opacity: 0; transform: translateY(24px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
-
-  @keyframes fade-in-down {
-    from { opacity: 0; transform: translateY(-12px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
-
-  @media (prefers-reduced-motion: no-preference) {
-    .hero-badge,
-    .hero h1,
-    .hero-subtitle,
-    .hero-actions,
-    .hero-stats,
-    .hero-showcase {
-      /* Animations defined inline above via animation property */
-    }
-  }
-
   @media (prefers-reduced-motion: reduce) {
-    .hero-badge,
-    .hero h1,
-    .hero-subtitle,
-    .hero-actions,
-    .hero-stats,
-    .hero-showcase {
-      animation: none !important;
-      opacity: 1 !important;
-    }
-
-    .hero-gradient-orb {
-      animation: none !important;
-    }
-
-    .hero-line-1 {
-      animation: none !important;
-    }
-
-    .hero-badge-dot {
-      animation: none !important;
-    }
-  }
-
-  /* ── Responsive ── */
-  @media (max-width: 900px) {
-    .features-grid {
-      grid-template-columns: 1fr;
+    .home-page :global(.btn) {
+      transition: none !important;
     }
   }
 
   @media (max-width: 768px) {
-    .section {
+    .home-page :global(.section) {
       padding: 4rem 1rem;
     }
 
-    .hero {
-      padding: calc(var(--navbar-height) + 3rem) 1rem 0;
-      min-height: auto;
-    }
-
-    .hero h1 {
-      font-size: 2.5rem;
-    }
-
-    .hero-subtitle {
-      font-size: 1rem;
-    }
-
-    .hero-stats {
-      gap: 1rem;
-    }
-
-    .hero-stat-value {
-      font-size: 1.1rem;
-    }
-
-    .hero-showcase {
-      margin-top: 3rem;
-    }
-
-    .hero-showcase-track {
-      transform: rotateX(2deg);
-      gap: 0.75rem;
-      padding: 0 0.5rem;
-    }
-
-    .hero-showcase-card {
-      flex: 0 0 280px;
-    }
-
-    .themes-bento {
-      grid-template-columns: repeat(2, 1fr);
-      grid-auto-rows: 160px;
-    }
-
-    .bento-1 { grid-column: span 2; grid-row: span 2; }
-    .bento-5 { grid-row: span 1; }
-
-    .section-header h2 {
+    .home-page :global(.section-header h2) {
       font-size: 1.6rem;
-    }
-
-    .themes-count {
-      border-left: none;
-      padding-left: 0;
-    }
-
-    .install-section {
-      padding-top: 4rem;
-      padding-bottom: 4rem;
-    }
-  }
-
-  @media (max-width: 480px) {
-    .hero h1 {
-      font-size: 2rem;
-    }
-
-    .hero-showcase-card {
-      flex: 0 0 240px;
-    }
-
-    .hero-stats {
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-
-    .hero-stat-divider {
-      display: none;
-    }
-
-    .hero-stat {
-      flex-direction: row;
-      gap: 0.5rem;
     }
   }
 </style>


### PR DESCRIPTION
## Summary

- Redesign homepage hero section with animated gradient orbs, noise texture, and grid background
- Add 3-card hero showcase (Marketplace, Custom Apps, Extensions) with perspective transform and frosted glass labels
- Replace theme gallery with a bento grid layout (6 themes with varied card sizes)
- Add features section with 4 interactive cards (Themes, Extensions, Custom Apps, CLI)
- Restyle install section with tabbed terminal block, OS auto-detection, and copy button
- Update community stats (22k+ stars, 18M+ downloads, 20k+ Discord, 200+ marketplace items)
- Fix SEO component to gracefully handle missing `Astro.site` config

## Test plan

- [x] Verify homepage renders correctly in both light and dark themes
- [x] Check hero showcase labels are visible and centered at the top of each card
- [x] Test install tab switching and OS auto-detection
- [x] Test copy-to-clipboard functionality
- [x] Verify responsive layout on mobile (480px, 768px) and desktop
- [x] Confirm bento grid themes display correctly at all breakpoints
- [x] Check all links navigate to correct destinations
- [x] Verify reduced-motion preferences are respected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned hero with animated gradients, dynamic stats, and image showcase
  * Modular homepage sections: Features showcase, Themes bento, and Install quick-start tabs
  * Responsive features grid and theme gallery with improved accessibility, keyboard navigation, and copy-to-clipboard for install commands
  * Font loading optimized for faster rendering

* **Bug Fixes**
  * SEO metadata now falls back to origin URL when base site info is unavailable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->