### PR TITLE
Add APT permission granting instructions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -202,6 +202,18 @@ When setting config values, use the full absolute path (e.g., `/home/username/..
 </details>
 
 <details>
+<summary>Spotify from APT</summary>
+
+Grant write permissions to Spotify's directory:
+
+```bash
+sudo chmod a+wr /usr/share/spotify
+sudo chmod a+wr /usr/share/spotify/Apps -R
+```
+
+</details>
+
+<details>
 <summary>Spotify from Snap</summary>
 
 Snap apps cannot be modified. You'll need to switch to the apt version:


### PR DESCRIPTION
Added instructions for granting write permissions to Spotify's directory when installed from APT. It always confused me why you have to look in the "Spotify from Snap" section to find the instructions for APT. I don't see any reason for it to not be there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Linux setup documentation for Spotify installation via APT package manager.
  * Included step-by-step instructions for configuring the necessary system permissions to ensure Spotify functions correctly on Linux systems.
  * Covers write permission configuration for Spotify installation directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->