### PR TITLE
Fix links to Spicetify Creator documentation

### DIFF
--- a/docs/customization/custom-apps.md
+++ b/docs/customization/custom-apps.md
@@ -134,7 +134,7 @@ Custom apps are React applications. A basic app needs:
 - `index.js`: Main application code with a `render()` function
 - `manifest.json`: Metadata including name, icons, and optional subfiles
 
-For a streamlined development experience, check out **[Spicetify Creator](/docs/development/spicetify-creator)** which supports TypeScript, JSX, and hot reloading.
+For a streamlined development experience, check out **[Spicetify Creator](/docs/development/spicetify-creator/the-basics)** which supports TypeScript, JSX, and hot reloading.
 
 ---
 

--- a/docs/customization/extensions.md
+++ b/docs/customization/extensions.md
@@ -242,4 +242,4 @@ spicetify apply
 
 ## Creating Extensions
 
-Want to build your own extension? See the **[Development Guide](/docs/development)** and **[Spicetify Creator](/docs/development/spicetify-creator)** for tools and tutorials.
+Want to build your own extension? See the **[Development Guide](/docs/development)** and **[Spicetify Creator](/docs/development/spicetify-creator/the-basics)** for tools and tutorials.

--- a/docs/development/extensions.md
+++ b/docs/development/extensions.md
@@ -218,7 +218,7 @@ Spicetify.PopupModal.display({
 
 ## Spicetify Creator
 
-For a better development experience with TypeScript, JSX, and hot reloading, use **[Spicetify Creator](/docs/development/spicetify-creator)**.
+For a better development experience with TypeScript, JSX, and hot reloading, use **[Spicetify Creator](/docs/development/spicetify-creator/the-basics)**.
 
 ```bash
 npx spicetify-creator
@@ -283,6 +283,6 @@ To share your extension:
 ## Resources
 
 - **[API Wrapper Reference](/docs/development/api-wrapper)**: Complete API documentation
-- **[Spicetify Creator](/docs/development/spicetify-creator)**: TypeScript development tool
+- **[Spicetify Creator](/docs/development/spicetify-creator/the-basics)**: TypeScript development tool
 - **[Built-in Extensions](https://github.com/spicetify/cli/tree/main/Extensions)**: Reference implementations
 - **[Marketplace Extensions](https://github.com/spicetify/marketplace)**: Community examples

--- a/docs/development/extensions.md
+++ b/docs/development/extensions.md
@@ -15,7 +15,7 @@ Extensions are JavaScript files that run alongside Spotify's main code. They can
 └── ...
 ```
 
-Extensions are single JavaScript files. For complex extensions with multiple files, use [Spicetify Creator](/docs/development/spicetify-creator).
+Extensions are single JavaScript files. For complex extensions with multiple files, use [Spicetify Creator](/docs/development/spicetify-creator/the-basics).
 
 ## Getting Started
 

--- a/src/content/docs/customization/custom-apps.md
+++ b/src/content/docs/customization/custom-apps.md
@@ -134,7 +134,7 @@ Custom apps are React applications. A basic app needs:
 - `index.js`: Main application code with a `render()` function
 - `manifest.json`: Metadata including name, icons, and optional subfiles
 
-For a streamlined development experience, check out **[Spicetify Creator](/docs/development/spicetify-creator)** which supports TypeScript, JSX, and hot reloading.
+For a streamlined development experience, check out **[Spicetify Creator](/docs/development/spicetify-creator/the-basics)** which supports TypeScript, JSX, and hot reloading.
 
 ---
 

--- a/src/content/docs/customization/extensions.md
+++ b/src/content/docs/customization/extensions.md
@@ -242,4 +242,4 @@ spicetify apply
 
 ## Creating Extensions
 
-Want to build your own extension? See the **[Development Guide](/docs/development)** and **[Spicetify Creator](/docs/development/spicetify-creator)** for tools and tutorials.
+Want to build your own extension? See the **[Development Guide](/docs/development)** and **[Spicetify Creator](/docs/development/spicetify-creator/the-basics)** for tools and tutorials.

--- a/src/content/docs/development/extensions.md
+++ b/src/content/docs/development/extensions.md
@@ -15,7 +15,7 @@ Extensions are JavaScript files that run alongside Spotify's main code. They can
 └── ...
 ```
 
-Extensions are single JavaScript files. For complex extensions with multiple files, use [Spicetify Creator](/docs/development/spicetify-creator).
+Extensions are single JavaScript files. For complex extensions with multiple files, use [Spicetify Creator](/docs/development/spicetify-creator/the-basics).
 
 ## Getting Started
 
@@ -218,7 +218,7 @@ Spicetify.PopupModal.display({
 
 ## Spicetify Creator
 
-For a better development experience with TypeScript, JSX, and hot reloading, use **[Spicetify Creator](/docs/development/spicetify-creator)**.
+For a better development experience with TypeScript, JSX, and hot reloading, use **[Spicetify Creator](/docs/development/spicetify-creator/the-basics)**.
 
 ```bash
 npx spicetify-creator
@@ -283,6 +283,6 @@ To share your extension:
 ## Resources
 
 - **[API Wrapper Reference](/docs/development/api-wrapper)**: Complete API documentation
-- **[Spicetify Creator](/docs/development/spicetify-creator)**: TypeScript development tool
+- **[Spicetify Creator](/docs/development/spicetify-creator/the-basics)**: TypeScript development tool
 - **[Built-in Extensions](https://github.com/spicetify/cli/tree/main/Extensions)**: Reference implementations
 - **[Marketplace Extensions](https://github.com/spicetify/marketplace)**: Community examples


### PR DESCRIPTION
Updated links for Spicetify Creator documentation.

Fixes #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated extension development documentation links to point users directly to the relevant "Spicetify Creator — The Basics" page for clearer navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->