### PR TITLE
Add Spotify APT permissions instructions

### DIFF
--- a/src/content/docs/getting-started.mdx
+++ b/src/content/docs/getting-started.mdx
@@ -202,6 +202,18 @@ When setting config values, use the full absolute path (e.g., `/home/username/..
 </details>
 
 <details>
+<summary>Spotify from APT</summary>
+
+Grant write permissions to Spotify's directory:
+
+```bash
+sudo chmod a+wr /usr/share/spotify
+sudo chmod a+wr /usr/share/spotify/Apps -R
+```
+
+</details>
+
+<details>
 <summary>Spotify from Snap</summary>
 
 Snap apps cannot be modified. You'll need to switch to the apt version:


### PR DESCRIPTION
Turns out there were 2 documentation files and I only changed one of them in my last pull request, and that wasn't the one the website was pulling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup instructions for Spotify installation on Linux via APT, including file permission configuration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->