### PR TITLE
Update getting-started.mdx by removing warning

### DIFF
--- a/src/content/docs/getting-started.mdx
+++ b/src/content/docs/getting-started.mdx
@@ -194,11 +194,6 @@ The `spotify-launcher` package installs Spotify to a user directory. Set the pat
 ```bash
 spicetify config spotify_path "$HOME/.local/share/spotify-launcher/install/usr/share/spotify"
 ```
-
-:::warning
-When setting config values, use the full absolute path (e.g., `/home/username/...`). The `~` shortcut works in shell commands but not in config values.
-:::
-
 </details>
 
 <details>


### PR DESCRIPTION
Irrelevant warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified the Spotify setup instructions for Arch Linux.
  - Removed the warning about using absolute paths and the limitations of `~` in configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->